### PR TITLE
Java 17 + Jakarta EE 10 migration (Spring Boot 3 support)

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="17" />
   </component>
   <component name="JavacSettings">
     <option name="ADDITIONAL_OPTIONS_OVERRIDE">

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,6 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,5 +10,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="15" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="openjdk-17" project-jdk-type="JavaSDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Add these dependency to your project's POM:
     <dependency>
         <groupId>org.sendbird</groupId>
         <artifactId>sendbird-platform-sdk</artifactId>
-        <version>1.0.20</version>
+        <version>1.1.0</version>
     </dependency>
 </dependencies>
 ```
@@ -103,7 +103,7 @@ Add this dependency to your project's build file:
 ```groovy
 
 dependencies {
-    implementation "org.sendbird:sendbird-platform-sdk:1.0.20"
+    implementation "org.sendbird:sendbird-platform-sdk:1.1.0"
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'com.diffplug.spotless'
 
 group = 'org.sendbird'
-version = '1.0.20'
+version = '1.1.0'
 
 buildscript {
     repositories {
@@ -78,8 +78,8 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 
     publishing {
         publications {
@@ -102,8 +102,8 @@ ext {
     jackson_version = "2.13.2"
     jackson_databind_version = "2.13.2.2"
     jackson_databind_nullable_version = "0.2.2"
-    jakarta_annotation_version = "1.3.5"
-    jersey_version = "2.35"
+    jakarta_annotation_version = "2.1.1"
+    jersey_version = "3.1.5"
     junit_version = "5.8.2"
 }
 
@@ -151,7 +151,7 @@ spotless {
     java {
         // don't need to set target, it is inferred from java
         // apply a specific flavor of google-java-format
-        googleJavaFormat('1.8').aosp().reflowLongStrings()
+        googleJavaFormat('17').aosp().reflowLongStrings()
         removeUnusedImports()
         importOrder()
     }

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ lazy val root = (project in file(".")).
   settings(
     organization := "org.sendbird",
     name := "sendbird-platform-sdk",
-    version := "1.0.20",
-    scalaVersion := "2.11.4",
+    version := "1.1.0",
+    scalaVersion := "2.13.6",
     scalacOptions ++= Seq("-feature"),
     Compile / javacOptions ++= Seq("-Xlint:deprecation"),
     Compile / packageDoc / publishArtifact := false,
@@ -11,17 +11,17 @@ lazy val root = (project in file(".")).
     libraryDependencies ++= Seq(
       "com.google.code.findbugs" % "jsr305" % "3.0.0",
       "io.swagger" % "swagger-annotations" % "1.6.5",
-      "org.glassfish.jersey.core" % "jersey-client" % "2.35",
-      "org.glassfish.jersey.inject" % "jersey-hk2" % "2.35",
-      "org.glassfish.jersey.media" % "jersey-media-multipart" % "2.35",
-      "org.glassfish.jersey.media" % "jersey-media-json-jackson" % "2.35",
-      "org.glassfish.jersey.connectors" % "jersey-apache-connector" % "2.35",
+      "org.glassfish.jersey.core" % "jersey-client" % "3.1.5",
+      "org.glassfish.jersey.inject" % "jersey-hk2" % "3.1.5",
+      "org.glassfish.jersey.media" % "jersey-media-multipart" % "3.1.5",
+      "org.glassfish.jersey.media" % "jersey-media-json-jackson" % "3.1.5",
+      "org.glassfish.jersey.connectors" % "jersey-apache-connector" % "3.1.5",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.13.2" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.13.2" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2.2" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.2" % "compile",
       "org.openapitools" % "jackson-databind-nullable" % "0.2.2" % "compile",
-      "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
+      "jakarta.annotation" % "jakarta.annotation-api" % "2.1.1" % "compile",
       "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )
   )

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>sendbird-platform-sdk</artifactId>
     <packaging>jar</packaging>
     <name>sendbird-platform-sdk</name>
-    <version>1.0.20</version>
+    <version>1.1.0</version>
     <url>https://github.com/sendbird/sendbird-platform-sdk-java</url>
     <description>Sendbird Platform API SDK</description>
     <scm>
@@ -135,8 +135,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                     <fork>true</fork>
                     <meminitial>128m</meminitial>
                     <maxmem>512m</maxmem>
@@ -160,7 +160,7 @@
                 </executions>
                 <configuration>
                     <doclint>none</doclint>
-                    <source>1.8</source>
+                    <source>17</source>
                     <tags>
                         <tag>
                             <name>http.response.details</name>
@@ -214,7 +214,7 @@
 
                   <!-- apply a specific flavor of google-java-format and reflow long strings -->
                   <googleJavaFormat>
-                    <version>1.8</version>
+                    <version>17</version>
                     <style>AOSP</style>
                     <reflowLongStrings>true</reflowLongStrings>
                   </googleJavaFormat>
@@ -334,11 +334,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.5</swagger-annotations-version>
-        <jersey-version>2.35</jersey-version>
+        <jersey-version>3.1.5</jersey-version>
         <jackson-version>2.13.2</jackson-version>
         <jackson-databind-version>2.13.2.2</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
-        <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
+        <jakarta-annotation-version>2.1.1</jakarta-annotation-version>
         <junit-version>5.8.2</junit-version>
         <spotless.version>2.21.0</spotless.version>
     </properties>

--- a/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -17,14 +17,14 @@ import org.sendbird.client.ApiException;
 import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationData.java
+++ b/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationData.java
@@ -43,7 +43,7 @@ import org.sendbird.client.JSON;
   AddApnsPushConfigurationData.JSON_PROPERTY_APNS_TYPE
 })
 @JsonTypeName("addApnsPushConfigurationData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddApnsPushConfigurationData {
   public static final String JSON_PROPERTY_APNS_CERT = "apns_cert";
   private File apnsCert;
@@ -81,7 +81,7 @@ public class AddApnsPushConfigurationData {
    * In a form of the &#x60;multipart/form-data&#x60; content type, specifies a [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file of which type is either development or production. Sendbird server scans the content of the file, finds out the certificate type, and then registers the file as the corresponding type. If you upload a wrong file, you will receive an error.
    * @return apnsCert
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "In a form of the `multipart/form-data` content type, specifies a [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file of which type is either development or production. Sendbird server scans the content of the file, finds out the certificate type, and then registers the file as the corresponding type. If you upload a wrong file, you will receive an error.")
   @JsonProperty(JSON_PROPERTY_APNS_CERT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -107,7 +107,7 @@ public class AddApnsPushConfigurationData {
    * Specifies the certificate type of the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file. Acceptable values are development and production. There is no need to specify this property when the apns_cert above is specified.
    * @return apnsCertEnvType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the certificate type of the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file. Acceptable values are development and production. There is no need to specify this property when the apns_cert above is specified.")
   @JsonProperty(JSON_PROPERTY_APNS_CERT_ENV_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -133,7 +133,7 @@ public class AddApnsPushConfigurationData {
    * Specifies the password of the cerfificate file which has been set during the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) export.
    * @return apnsCertPassword
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the password of the cerfificate file which has been set during the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) export.")
   @JsonProperty(JSON_PROPERTY_APNS_CERT_PASSWORD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -159,7 +159,7 @@ public class AddApnsPushConfigurationData {
    * Determines whether to badge your client app&#39;s icon with the number of a user&#39;s unread messages. (Default: true)
    * @return hasUnreadCountBadge
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to badge your client app's icon with the number of a user's unread messages. (Default: true)")
   @JsonProperty(JSON_PROPERTY_HAS_UNREAD_COUNT_BADGE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -185,7 +185,7 @@ public class AddApnsPushConfigurationData {
    * Determines for your client app whether to perform a silent background update on a user&#39;s device. For more information, see the Apple Developer Documentation&#39;s [Pushing Updates to Your App Silently](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_updates_to_your_app_silently). (Default: false)
    * @return contentAvailable
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines for your client app whether to perform a silent background update on a user's device. For more information, see the Apple Developer Documentation's [Pushing Updates to Your App Silently](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_updates_to_your_app_silently). (Default: false)")
   @JsonProperty(JSON_PROPERTY_CONTENT_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -211,7 +211,7 @@ public class AddApnsPushConfigurationData {
    * Determines for your client app whether or not to modify the payload of a push notification before it is displayed on a user&#39;s device. For more information, see the Apple Developer Documentation&#39;s [Modifying Content in Newly Delivered Notifications](https://developer.apple.com/documentation/usernotifications/modifying_content_in_newly_delivered_notifications). (Default: false)
    * @return mutableContent
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines for your client app whether or not to modify the payload of a push notification before it is displayed on a user's device. For more information, see the Apple Developer Documentation's [Modifying Content in Newly Delivered Notifications](https://developer.apple.com/documentation/usernotifications/modifying_content_in_newly_delivered_notifications). (Default: false)")
   @JsonProperty(JSON_PROPERTY_MUTABLE_CONTENT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -237,7 +237,7 @@ public class AddApnsPushConfigurationData {
    * Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file can be in the app&#39;s main bundle or in the &#x60;Library/Sounds&#x60; folder of the app&#39;s data container.
    * @return pushSound
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file can be in the app's main bundle or in the `Library/Sounds` folder of the app's data container.")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -263,7 +263,7 @@ public class AddApnsPushConfigurationData {
    * (Deprecated)  Specifies the certificate type of the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file. Acceptable values are development and production. You should specify either this property or the apns_cert above to inform the server of which certificate type to update.
    * @return apnsType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "(Deprecated)  Specifies the certificate type of the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file. Acceptable values are development and production. You should specify either this property or the apns_cert above to inform the server of which certificate type to update.")
   @JsonProperty(JSON_PROPERTY_APNS_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddApnsPushConfigurationResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("addApnsPushConfigurationResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddApnsPushConfigurationResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<AddApnsPushConfigurationResponsePushConfigurationsInner> pushConfigurations = null;
@@ -63,7 +63,7 @@ public class AddApnsPushConfigurationResponse {
    * Get pushConfigurations
    * @return pushConfigurations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_CONFIGURATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationResponsePushConfigurationsInner.java
+++ b/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationResponsePushConfigurationsInner.java
@@ -45,7 +45,7 @@ import org.sendbird.client.JSON;
   AddApnsPushConfigurationResponsePushConfigurationsInner.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("addApnsPushConfigurationResponse_push_configurations_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddApnsPushConfigurationResponsePushConfigurationsInner {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;
@@ -89,7 +89,7 @@ public class AddApnsPushConfigurationResponsePushConfigurationsInner {
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -115,7 +115,7 @@ public class AddApnsPushConfigurationResponsePushConfigurationsInner {
    * Get pushType
    * @return pushType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -141,7 +141,7 @@ public class AddApnsPushConfigurationResponsePushConfigurationsInner {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -167,7 +167,7 @@ public class AddApnsPushConfigurationResponsePushConfigurationsInner {
    * Get apnsCerEnvType
    * @return apnsCerEnvType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_APNS_CER_ENV_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -193,7 +193,7 @@ public class AddApnsPushConfigurationResponsePushConfigurationsInner {
    * Get apnsExpiration
    * @return apnsExpiration
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_APNS_EXPIRATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -219,7 +219,7 @@ public class AddApnsPushConfigurationResponsePushConfigurationsInner {
    * Get apnsName
    * @return apnsName
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_APNS_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -245,7 +245,7 @@ public class AddApnsPushConfigurationResponsePushConfigurationsInner {
    * Get hasUnreadCountBadge
    * @return hasUnreadCountBadge
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_HAS_UNREAD_COUNT_BADGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -271,7 +271,7 @@ public class AddApnsPushConfigurationResponsePushConfigurationsInner {
    * Get contentAvailable
    * @return contentAvailable
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CONTENT_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -297,7 +297,7 @@ public class AddApnsPushConfigurationResponsePushConfigurationsInner {
    * Get mutableContent
    * @return mutableContent
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MUTABLE_CONTENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -323,7 +323,7 @@ public class AddApnsPushConfigurationResponsePushConfigurationsInner {
    * Get pushSound
    * @return pushSound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddEmojiCategoriesResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddEmojiCategoriesResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddEmojiCategoriesResponse.JSON_PROPERTY_EMOJI_CATEGORIES
 })
 @JsonTypeName("addEmojiCategoriesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddEmojiCategoriesResponse {
   public static final String JSON_PROPERTY_EMOJI_CATEGORIES = "emoji_categories";
   private List<AddEmojiCategoriesResponseEmojiCategoriesInner> emojiCategories = null;
@@ -63,7 +63,7 @@ public class AddEmojiCategoriesResponse {
    * Get emojiCategories
    * @return emojiCategories
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EMOJI_CATEGORIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddEmojiCategoriesResponseEmojiCategoriesInner.java
+++ b/src/main/java/org/openapitools/client/model/AddEmojiCategoriesResponseEmojiCategoriesInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddEmojiCategoriesResponseEmojiCategoriesInner.JSON_PROPERTY_URL
 })
 @JsonTypeName("addEmojiCategoriesResponse_emoji_categories_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddEmojiCategoriesResponseEmojiCategoriesInner {
   public static final String JSON_PROPERTY_ID = "id";
   private BigDecimal id;
@@ -61,7 +61,7 @@ public class AddEmojiCategoriesResponseEmojiCategoriesInner {
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -87,7 +87,7 @@ public class AddEmojiCategoriesResponseEmojiCategoriesInner {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -113,7 +113,7 @@ public class AddEmojiCategoriesResponseEmojiCategoriesInner {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddEmojisData.java
+++ b/src/main/java/org/openapitools/client/model/AddEmojisData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddEmojisData.JSON_PROPERTY_EMOJIS
 })
 @JsonTypeName("addEmojisData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddEmojisData {
   public static final String JSON_PROPERTY_EMOJI_CATEGORY_ID = "emoji_category_id";
   private Integer emojiCategoryId;
@@ -58,7 +58,7 @@ public class AddEmojisData {
    * Specifies the unique ID of the emoji category that a list of new emojis belong to.
    * @return emojiCategoryId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the emoji category that a list of new emojis belong to.")
   @JsonProperty(JSON_PROPERTY_EMOJI_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -89,7 +89,7 @@ public class AddEmojisData {
    * Specifies a list of one or more new emojis to register.
    * @return emojis
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a list of one or more new emojis to register.")
   @JsonProperty(JSON_PROPERTY_EMOJIS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/AddEmojisResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddEmojisResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddEmojisResponse.JSON_PROPERTY_EMOJIS
 })
 @JsonTypeName("addEmojisResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddEmojisResponse {
   public static final String JSON_PROPERTY_EMOJIS = "emojis";
   private List<ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisInner> emojis = null;
@@ -63,7 +63,7 @@ public class AddEmojisResponse {
    * Get emojis
    * @return emojis
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EMOJIS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddExtraDataToMessageData.java
+++ b/src/main/java/org/openapitools/client/model/AddExtraDataToMessageData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddExtraDataToMessageData.JSON_PROPERTY_SORTED_METAARRAY
 })
 @JsonTypeName("addExtraDataToMessageData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddExtraDataToMessageData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;
@@ -64,7 +64,7 @@ public class AddExtraDataToMessageData {
    * Specifies the type of the channel. Either open_channels or group_channels.
    * @return channelType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the type of the channel. Either open_channels or group_channels.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -90,7 +90,7 @@ public class AddExtraDataToMessageData {
    * Specifies the URL of the target channel.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the target channel.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -116,7 +116,7 @@ public class AddExtraDataToMessageData {
    * Specifies the unique ID of the message to add key-values items for additional information.
    * @return messageId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the message to add key-values items for additional information.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -142,7 +142,7 @@ public class AddExtraDataToMessageData {
    * Specifies a &#x60;JSON&#x60; object of one or more key-values items which store additional message information. Each item consists of a key and the values in an array. Items are saved and will be returned in the exact order they&#39;ve been specified.
    * @return sortedMetaarray
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a `JSON` object of one or more key-values items which store additional message information. Each item consists of a key and the values in an array. Items are saved and will be returned in the exact order they've been specified.")
   @JsonProperty(JSON_PROPERTY_SORTED_METAARRAY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/AddExtraDataToMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddExtraDataToMessageResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddExtraDataToMessageResponse.JSON_PROPERTY_SORTED_METAARRAY
 })
 @JsonTypeName("addExtraDataToMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddExtraDataToMessageResponse {
   public static final String JSON_PROPERTY_SORTED_METAARRAY = "sorted_metaarray";
   private List<ListMessagesResponseMessagesInnerSortedMetaarrayInner> sortedMetaarray = null;
@@ -63,7 +63,7 @@ public class AddExtraDataToMessageResponse {
    * Get sortedMetaarray
    * @return sortedMetaarray
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SORTED_METAARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationData.java
+++ b/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   AddFcmPushConfigurationData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("addFcmPushConfigurationData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddFcmPushConfigurationData {
   public static final String JSON_PROPERTY_API_KEY = "api_key";
   private String apiKey;
@@ -56,7 +56,7 @@ public class AddFcmPushConfigurationData {
    * Specifies the FCM server key to register.
    * @return apiKey
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the FCM server key to register.")
   @JsonProperty(JSON_PROPERTY_API_KEY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -82,7 +82,7 @@ public class AddFcmPushConfigurationData {
    * Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file should be located in the &#x60;/res/raw&#x60; folder.
    * @return pushSound
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file should be located in the `/res/raw` folder.")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddFcmPushConfigurationResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("addFcmPushConfigurationResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddFcmPushConfigurationResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<AddFcmPushConfigurationResponsePushConfigurationsInner> pushConfigurations = null;
@@ -63,7 +63,7 @@ public class AddFcmPushConfigurationResponse {
    * Get pushConfigurations
    * @return pushConfigurations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_CONFIGURATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationResponsePushConfigurationsInner.java
+++ b/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationResponsePushConfigurationsInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddFcmPushConfigurationResponsePushConfigurationsInner.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("addFcmPushConfigurationResponse_push_configurations_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddFcmPushConfigurationResponsePushConfigurationsInner {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;
@@ -64,7 +64,7 @@ public class AddFcmPushConfigurationResponsePushConfigurationsInner {
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -90,7 +90,7 @@ public class AddFcmPushConfigurationResponsePushConfigurationsInner {
    * Get pushType
    * @return pushType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -116,7 +116,7 @@ public class AddFcmPushConfigurationResponsePushConfigurationsInner {
    * Get apiKey
    * @return apiKey
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_API_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -142,7 +142,7 @@ public class AddFcmPushConfigurationResponsePushConfigurationsInner {
    * Get pushSound
    * @return pushSound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationData.java
+++ b/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   AddHmsPushConfigurationData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("addHmsPushConfigurationData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddHmsPushConfigurationData {
   public static final String JSON_PROPERTY_HUAWEI_APP_ID = "huawei_app_id";
   private String huaweiAppId;
@@ -60,7 +60,7 @@ public class AddHmsPushConfigurationData {
    * Specifies the unique ID of application registered to the HMS server.
    * @return huaweiAppId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of application registered to the HMS server.")
   @JsonProperty(JSON_PROPERTY_HUAWEI_APP_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class AddHmsPushConfigurationData {
    * Specifies the secret key allocated to the application.
    * @return huaweiAppSecret
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the secret key allocated to the application.")
   @JsonProperty(JSON_PROPERTY_HUAWEI_APP_SECRET)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class AddHmsPushConfigurationData {
    * Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file should be located in the &#x60;/res/raw&#x60; folder.
    * @return pushSound
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file should be located in the `/res/raw` folder.")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddHmsPushConfigurationResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("addHmsPushConfigurationResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddHmsPushConfigurationResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<AddHmsPushConfigurationResponsePushConfigurationsInner> pushConfigurations = null;
@@ -63,7 +63,7 @@ public class AddHmsPushConfigurationResponse {
    * Get pushConfigurations
    * @return pushConfigurations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_CONFIGURATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationResponsePushConfigurationsInner.java
+++ b/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationResponsePushConfigurationsInner.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   AddHmsPushConfigurationResponsePushConfigurationsInner.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("addHmsPushConfigurationResponse_push_configurations_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddHmsPushConfigurationResponsePushConfigurationsInner {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;
@@ -68,7 +68,7 @@ public class AddHmsPushConfigurationResponsePushConfigurationsInner {
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class AddHmsPushConfigurationResponsePushConfigurationsInner {
    * Get pushType
    * @return pushType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -120,7 +120,7 @@ public class AddHmsPushConfigurationResponsePushConfigurationsInner {
    * Get huaweiAppId
    * @return huaweiAppId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_HUAWEI_APP_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -146,7 +146,7 @@ public class AddHmsPushConfigurationResponsePushConfigurationsInner {
    * Get huaweiAppSecret
    * @return huaweiAppSecret
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_HUAWEI_APP_SECRET)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -172,7 +172,7 @@ public class AddHmsPushConfigurationResponsePushConfigurationsInner {
    * Get pushSound
    * @return pushSound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddIpToWhitelistData.java
+++ b/src/main/java/org/openapitools/client/model/AddIpToWhitelistData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   AddIpToWhitelistData.JSON_PROPERTY_IP_WHITELIST_ADDRESSES
 })
 @JsonTypeName("addIpToWhitelistData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddIpToWhitelistData {
   public static final String JSON_PROPERTY_IP_WHITELIST_ADDRESSES = "ip_whitelist_addresses";
   private List<String> ipWhitelistAddresses = new ArrayList<>();
@@ -59,7 +59,7 @@ public class AddIpToWhitelistData {
    * Specifies an array of one or more IP ranges and addresses to add to a whitelist.
    * @return ipWhitelistAddresses
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more IP ranges and addresses to add to a whitelist.")
   @JsonProperty(JSON_PROPERTY_IP_WHITELIST_ADDRESSES)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/AddIpToWhitelistResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddIpToWhitelistResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   AddIpToWhitelistResponse.JSON_PROPERTY_IP_WHITELIST_ADDRESSES
 })
 @JsonTypeName("addIpToWhitelistResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddIpToWhitelistResponse {
   public static final String JSON_PROPERTY_IP_WHITELIST_ADDRESSES = "ip_whitelist_addresses";
   private List<String> ipWhitelistAddresses = null;
@@ -62,7 +62,7 @@ public class AddIpToWhitelistResponse {
    * Get ipWhitelistAddresses
    * @return ipWhitelistAddresses
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IP_WHITELIST_ADDRESSES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddReactionToAMessageData.java
+++ b/src/main/java/org/openapitools/client/model/AddReactionToAMessageData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   AddReactionToAMessageData.JSON_PROPERTY_REACTION
 })
 @JsonTypeName("addReactionToAMessageData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddReactionToAMessageData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;
@@ -68,7 +68,7 @@ public class AddReactionToAMessageData {
    * Specifies the type of the channel. Currently, a value of group_channels is only available for the parameter.
    * @return channelType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the type of the channel. Currently, a value of group_channels is only available for the parameter.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -94,7 +94,7 @@ public class AddReactionToAMessageData {
    * Specifies the URL of the target channel.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the target channel.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -120,7 +120,7 @@ public class AddReactionToAMessageData {
    * Specifies the unique ID of the message to add a reaction to.
    * @return messageId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the message to add a reaction to.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -146,7 +146,7 @@ public class AddReactionToAMessageData {
    * Specifies the ID of the user who reacts to the message.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the user who reacts to the message.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -172,7 +172,7 @@ public class AddReactionToAMessageData {
    * Specifies the unique key of the reaction to be added to the message. The length is limited to 192 charaters.
    * @return reaction
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique key of the reaction to be added to the message. The length is limited to 192 charaters.")
   @JsonProperty(JSON_PROPERTY_REACTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/AddReactionToAMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddReactionToAMessageResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   AddReactionToAMessageResponse.JSON_PROPERTY_MSG_ID
 })
 @JsonTypeName("addReactionToAMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddReactionToAMessageResponse {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -73,7 +73,7 @@ public class AddReactionToAMessageResponse {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -99,7 +99,7 @@ public class AddReactionToAMessageResponse {
    * Get operation
    * @return operation
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPERATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -125,7 +125,7 @@ public class AddReactionToAMessageResponse {
    * Get success
    * @return success
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SUCCESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -151,7 +151,7 @@ public class AddReactionToAMessageResponse {
    * Get reaction
    * @return reaction
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REACTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -177,7 +177,7 @@ public class AddReactionToAMessageResponse {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -203,7 +203,7 @@ public class AddReactionToAMessageResponse {
    * Get msgId
    * @return msgId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MSG_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/AddRegistrationOrDeviceTokenData.java
+++ b/src/main/java/org/openapitools/client/model/AddRegistrationOrDeviceTokenData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   AddRegistrationOrDeviceTokenData.JSON_PROPERTY_APNS_DEVICE_TOKEN
 })
 @JsonTypeName("addRegistrationOrDeviceTokenData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddRegistrationOrDeviceTokenData {
   public static final String JSON_PROPERTY_GCM_REG_TOKEN = "gcm_reg_token";
   private String gcmRegToken;
@@ -60,7 +60,7 @@ public class AddRegistrationOrDeviceTokenData {
    * Specifies a registration token for Firebase Cloud Messaging (formerly [Google Cloud Messaging](https://developers.google.com/cloud-messaging/)).
    * @return gcmRegToken
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a registration token for Firebase Cloud Messaging (formerly [Google Cloud Messaging](https://developers.google.com/cloud-messaging/)).")
   @JsonProperty(JSON_PROPERTY_GCM_REG_TOKEN)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class AddRegistrationOrDeviceTokenData {
    * Specifies a device token for Huawei Mobile Services.
    * @return huaweiDeviceToken
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a device token for Huawei Mobile Services.")
   @JsonProperty(JSON_PROPERTY_HUAWEI_DEVICE_TOKEN)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class AddRegistrationOrDeviceTokenData {
    * Specifies a device token for Apple Push Notification Service.
    * @return apnsDeviceToken
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a device token for Apple Push Notification Service.")
   @JsonProperty(JSON_PROPERTY_APNS_DEVICE_TOKEN)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/AddRegistrationOrDeviceTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddRegistrationOrDeviceTokenResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddRegistrationOrDeviceTokenResponse.JSON_PROPERTY_USER
 })
 @JsonTypeName("addRegistrationOrDeviceTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AddRegistrationOrDeviceTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;
@@ -61,7 +61,7 @@ public class AddRegistrationOrDeviceTokenResponse {
    * Get token
    * @return token
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -87,7 +87,7 @@ public class AddRegistrationOrDeviceTokenResponse {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -113,7 +113,7 @@ public class AddRegistrationOrDeviceTokenResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/BanFromChannelsWithCustomChannelTypesData.java
+++ b/src/main/java/org/openapitools/client/model/BanFromChannelsWithCustomChannelTypesData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   BanFromChannelsWithCustomChannelTypesData.JSON_PROPERTY_CHANNEL_CUSTOM_TYPES
 })
 @JsonTypeName("banFromChannelsWithCustomChannelTypesData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class BanFromChannelsWithCustomChannelTypesData {
   public static final String JSON_PROPERTY_CHANNEL_CUSTOM_TYPES = "channel_custom_types";
   private List<String> channelCustomTypes = new ArrayList<>();
@@ -59,7 +59,7 @@ public class BanFromChannelsWithCustomChannelTypesData {
    * Specifies an array of one or more custom channel types, in order to ban the user from channels with the channel types. The user is permanently banned unless unbanned (10 years, technically).
    * @return channelCustomTypes
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more custom channel types, in order to ban the user from channels with the channel types. The user is permanently banned unless unbanned (10 years, technically).")
   @JsonProperty(JSON_PROPERTY_CHANNEL_CUSTOM_TYPES)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/BanUsersInChannelsWithCustomChannelTypeData.java
+++ b/src/main/java/org/openapitools/client/model/BanUsersInChannelsWithCustomChannelTypeData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   BanUsersInChannelsWithCustomChannelTypeData.JSON_PROPERTY_ON_DEMAND_UPSERT
 })
 @JsonTypeName("banUsersInChannelsWithCustomChannelTypeData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class BanUsersInChannelsWithCustomChannelTypeData {
   public static final String JSON_PROPERTY_BANNED_LIST = "banned_list";
   private List<BanUsersInChannelsWithCustomChannelTypeDataBannedListInner> bannedList = new ArrayList<>();
@@ -64,7 +64,7 @@ public class BanUsersInChannelsWithCustomChannelTypeData {
    * Get bannedList
    * @return bannedList
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "")
   @JsonProperty(JSON_PROPERTY_BANNED_LIST)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -90,7 +90,7 @@ public class BanUsersInChannelsWithCustomChannelTypeData {
    * Get onDemandUpsert
    * @return onDemandUpsert
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ON_DEMAND_UPSERT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/BanUsersInChannelsWithCustomChannelTypeDataBannedListInner.java
+++ b/src/main/java/org/openapitools/client/model/BanUsersInChannelsWithCustomChannelTypeDataBannedListInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   BanUsersInChannelsWithCustomChannelTypeDataBannedListInner.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("banUsersInChannelsWithCustomChannelTypeData_banned_list_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class BanUsersInChannelsWithCustomChannelTypeDataBannedListInner {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -61,7 +61,7 @@ public class BanUsersInChannelsWithCustomChannelTypeDataBannedListInner {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -87,7 +87,7 @@ public class BanUsersInChannelsWithCustomChannelTypeDataBannedListInner {
    * Get seconds
    * @return seconds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SECONDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -113,7 +113,7 @@ public class BanUsersInChannelsWithCustomChannelTypeDataBannedListInner {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/Blob.java
+++ b/src/main/java/org/openapitools/client/model/Blob.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   Blob.JSON_PROPERTY_SIZE,
   Blob.JSON_PROPERTY_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class Blob {
   public static final String JSON_PROPERTY_SIZE = "size";
   private BigDecimal size;
@@ -56,7 +56,7 @@ public class Blob {
    * Get size
    * @return size
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SIZE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -82,7 +82,7 @@ public class Blob {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/BlockUserData.java
+++ b/src/main/java/org/openapitools/client/model/BlockUserData.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   BlockUserData.JSON_PROPERTY_USERS
 })
 @JsonTypeName("blockUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class BlockUserData {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -66,7 +66,7 @@ public class BlockUserData {
    * Specifies the unique ID of the user to block.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the user to block.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -92,7 +92,7 @@ public class BlockUserData {
    * Specifies the ID of the user to be blocked.
    * @return targetId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the user to be blocked.")
   @JsonProperty(JSON_PROPERTY_TARGET_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -123,7 +123,7 @@ public class BlockUserData {
    * Specifies an array of the IDs of the users to be blocked at a time. (for bulk mode)
    * @return userIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of the IDs of the users to be blocked at a time. (for bulk mode)")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -154,7 +154,7 @@ public class BlockUserData {
    * Specifies an array of the IDs of the users to be blocked at a time. The user_ids above and this property can be used interchangeably. (for bulk mode)
    * @return users
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of the IDs of the users to be blocked at a time. The user_ids above and this property can be used interchangeably. (for bulk mode)")
   @JsonProperty(JSON_PROPERTY_USERS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/BlockUserResponse.java
+++ b/src/main/java/org/openapitools/client/model/BlockUserResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   BlockUserResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("blockUserResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class BlockUserResponse {
   public static final String JSON_PROPERTY_USERS = "users";
   private List<String> users = null;
@@ -66,7 +66,7 @@ public class BlockUserResponse {
    * Get users
    * @return users
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class BlockUserResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ChoosePushNotificationContentTemplateResponse.java
+++ b/src/main/java/org/openapitools/client/model/ChoosePushNotificationContentTemplateResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ChoosePushNotificationContentTemplateResponse.JSON_PROPERTY_NAME
 })
 @JsonTypeName("choosePushNotificationContentTemplateResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ChoosePushNotificationContentTemplateResponse {
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;
@@ -52,7 +52,7 @@ public class ChoosePushNotificationContentTemplateResponse {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToData.java
+++ b/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToData.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   ChooseWhichEventsToSubscribeToData.JSON_PROPERTY_ENABLED_EVENTS
 })
 @JsonTypeName("chooseWhichEventsToSubscribeToData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ChooseWhichEventsToSubscribeToData {
   public static final String JSON_PROPERTY_ENABLED = "enabled";
   private Boolean enabled;
@@ -66,7 +66,7 @@ public class ChooseWhichEventsToSubscribeToData {
    * Determines whether webhooks are turned on in your Sendbird application or not. (Default: false)
    * @return enabled
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether webhooks are turned on in your Sendbird application or not. (Default: false)")
   @JsonProperty(JSON_PROPERTY_ENABLED)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -92,7 +92,7 @@ public class ChooseWhichEventsToSubscribeToData {
    * Specifies the URL of your webhook server to receive payloads for events.
    * @return url
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of your webhook server to receive payloads for events.")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -118,7 +118,7 @@ public class ChooseWhichEventsToSubscribeToData {
    * Determines whether to include the information on the members of group channels in payloads. (Default: false)
    * @return includeMembers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to include the information on the members of group channels in payloads. (Default: false)")
   @JsonProperty(JSON_PROPERTY_INCLUDE_MEMBERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -152,7 +152,7 @@ public class ChooseWhichEventsToSubscribeToData {
    * Specifies an array of one or more [events](#2-webhook-events) for your webhook server to subscribe to. If set to an asterisk () only, the server will subscribe to all supported events. If set to an empty array, the server will unsubscribe from all (which indicates turning off webhooks).
    * @return enabledEvents
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more [events](#2-webhook-events) for your webhook server to subscribe to. If set to an asterisk () only, the server will subscribe to all supported events. If set to an empty array, the server will unsubscribe from all (which indicates turning off webhooks).")
   @JsonProperty(JSON_PROPERTY_ENABLED_EVENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToResponse.java
+++ b/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ChooseWhichEventsToSubscribeToResponse.JSON_PROPERTY_WEBHOOK
 })
 @JsonTypeName("chooseWhichEventsToSubscribeToResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ChooseWhichEventsToSubscribeToResponse {
   public static final String JSON_PROPERTY_WEBHOOK = "webhook";
   private ChooseWhichEventsToSubscribeToResponseWebhook webhook;
@@ -53,7 +53,7 @@ public class ChooseWhichEventsToSubscribeToResponse {
    * Get webhook
    * @return webhook
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_WEBHOOK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToResponseWebhook.java
+++ b/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToResponseWebhook.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   ChooseWhichEventsToSubscribeToResponseWebhook.JSON_PROPERTY_INCLUDE_UNREAD_COUNT
 })
 @JsonTypeName("chooseWhichEventsToSubscribeToResponse_webhook")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ChooseWhichEventsToSubscribeToResponseWebhook {
   public static final String JSON_PROPERTY_ENABLED = "enabled";
   private Boolean enabled;
@@ -70,7 +70,7 @@ public class ChooseWhichEventsToSubscribeToResponseWebhook {
    * Get enabled
    * @return enabled
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -96,7 +96,7 @@ public class ChooseWhichEventsToSubscribeToResponseWebhook {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -122,7 +122,7 @@ public class ChooseWhichEventsToSubscribeToResponseWebhook {
    * Get includeMembers
    * @return includeMembers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_INCLUDE_MEMBERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -156,7 +156,7 @@ public class ChooseWhichEventsToSubscribeToResponseWebhook {
    * Get enabledEvents
    * @return enabledEvents
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLED_EVENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -182,7 +182,7 @@ public class ChooseWhichEventsToSubscribeToResponseWebhook {
    * Get includeUnreadCount
    * @return includeUnreadCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_INCLUDE_UNREAD_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ConfigureAutoEventData.java
+++ b/src/main/java/org/openapitools/client/model/ConfigureAutoEventData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ConfigureAutoEventData.JSON_PROPERTY_AUTO_EVENT_MESSAGE
 })
 @JsonTypeName("configureAutoEventData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ConfigureAutoEventData {
   public static final String JSON_PROPERTY_AUTO_EVENT_MESSAGE = "auto_event_message";
   private ConfigureAutoEventDataAutoEventMessage autoEventMessage;
@@ -53,7 +53,7 @@ public class ConfigureAutoEventData {
    * Get autoEventMessage
    * @return autoEventMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_AUTO_EVENT_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ConfigureAutoEventDataAutoEventMessage.java
+++ b/src/main/java/org/openapitools/client/model/ConfigureAutoEventDataAutoEventMessage.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ConfigureAutoEventDataAutoEventMessage.JSON_PROPERTY_CHANNEL_CHANGE
 })
 @JsonTypeName("configureAutoEventData_auto_event_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ConfigureAutoEventDataAutoEventMessage {
   public static final String JSON_PROPERTY_USER_LEAVE = "user_leave";
   private Object userLeave;
@@ -64,7 +64,7 @@ public class ConfigureAutoEventDataAutoEventMessage {
    * Get userLeave
    * @return userLeave
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_LEAVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -90,7 +90,7 @@ public class ConfigureAutoEventDataAutoEventMessage {
    * Get userJoin
    * @return userJoin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_JOIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -116,7 +116,7 @@ public class ConfigureAutoEventDataAutoEventMessage {
    * Get channelCreate
    * @return channelCreate
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_CREATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -142,7 +142,7 @@ public class ConfigureAutoEventDataAutoEventMessage {
    * Get channelChange
    * @return channelChange
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_CHANGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/CreateBotData.java
+++ b/src/main/java/org/openapitools/client/model/CreateBotData.java
@@ -43,7 +43,7 @@ import org.sendbird.client.JSON;
   CreateBotData.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("createBotData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateBotData {
   public static final String JSON_PROPERTY_BOT_USERID = "bot_userid";
   private String botUserid;
@@ -84,7 +84,7 @@ public class CreateBotData {
    * Specifies the unique ID of the bot. The length is limited to 80 characters.
    * @return botUserid
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the bot. The length is limited to 80 characters.")
   @JsonProperty(JSON_PROPERTY_BOT_USERID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -110,7 +110,7 @@ public class CreateBotData {
    * Specifies the bot&#39;s nickname. The length is limited to 80 characters.
    * @return botNickname
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the bot's nickname. The length is limited to 80 characters.")
   @JsonProperty(JSON_PROPERTY_BOT_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -136,7 +136,7 @@ public class CreateBotData {
    * Specifies the URL of the bot&#39;s profile image. The size is limited to 2,048 characters.
    * @return botProfileUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the bot's profile image. The size is limited to 2,048 characters.")
   @JsonProperty(JSON_PROPERTY_BOT_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -162,7 +162,7 @@ public class CreateBotData {
    * Specifies the type of the bot that you can specify for categorization. The length is limited to 128 characters.
    * @return botType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the type of the bot that you can specify for categorization. The length is limited to 128 characters.")
   @JsonProperty(JSON_PROPERTY_BOT_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -188,7 +188,7 @@ public class CreateBotData {
    * Specifies the server URL where bot is located to receive all events, requests, and data forwarded from an application. For security reasons, it is highly recommended that you use an SSL server. The length is limited to 1,024 characters.
    * @return botCallbackUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the server URL where bot is located to receive all events, requests, and data forwarded from an application. For security reasons, it is highly recommended that you use an SSL server. The length is limited to 1,024 characters.")
   @JsonProperty(JSON_PROPERTY_BOT_CALLBACK_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -214,7 +214,7 @@ public class CreateBotData {
    * In the channels of where the bot is a member, determines whether to only forward the messages with the specific conditions to the bot or forword all messages to the bot, for privacy concerns. If set to true, only messages that start with a &#39;/&#39; or mention the bot_userid are forwarded to the bot. If set to false, all messages are forwarded.
    * @return isPrivacyMode
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "In the channels of where the bot is a member, determines whether to only forward the messages with the specific conditions to the bot or forword all messages to the bot, for privacy concerns. If set to true, only messages that start with a '/' or mention the bot_userid are forwarded to the bot. If set to false, all messages are forwarded.")
   @JsonProperty(JSON_PROPERTY_IS_PRIVACY_MODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -240,7 +240,7 @@ public class CreateBotData {
    * Determines whether to mark the bot&#39;s message as read upon sending it. (Default: true)
    * @return enableMarkAsRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to mark the bot's message as read upon sending it. (Default: true)")
   @JsonProperty(JSON_PROPERTY_ENABLE_MARK_AS_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -266,7 +266,7 @@ public class CreateBotData {
    * Determines whether to include information about the members of each channel in a callback response. (Default: false)
    * @return showMember
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to include information about the members of each channel in a callback response. (Default: false)")
   @JsonProperty(JSON_PROPERTY_SHOW_MEMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -292,7 +292,7 @@ public class CreateBotData {
    * Get channelInvitationPreference
    * @return channelInvitationPreference
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/CreateBotResponse.java
+++ b/src/main/java/org/openapitools/client/model/CreateBotResponse.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   CreateBotResponse.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("createBotResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateBotResponse {
   public static final String JSON_PROPERTY_BOT = "bot";
   private CreateBotResponseBot bot;
@@ -74,7 +74,7 @@ public class CreateBotResponse {
    * Get bot
    * @return bot
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -100,7 +100,7 @@ public class CreateBotResponse {
    * Get botCallbackUrl
    * @return botCallbackUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT_CALLBACK_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -126,7 +126,7 @@ public class CreateBotResponse {
    * Get enableMarkAsRead
    * @return enableMarkAsRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_MARK_AS_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -152,7 +152,7 @@ public class CreateBotResponse {
    * Get isPrivacyMode
    * @return isPrivacyMode
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_PRIVACY_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -178,7 +178,7 @@ public class CreateBotResponse {
    * Get showMember
    * @return showMember
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SHOW_MEMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -204,7 +204,7 @@ public class CreateBotResponse {
    * Get channelInvitationPreference
    * @return channelInvitationPreference
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/CreateBotResponseBot.java
+++ b/src/main/java/org/openapitools/client/model/CreateBotResponseBot.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   CreateBotResponseBot.JSON_PROPERTY_BOT_METADATA
 })
 @JsonTypeName("createBotResponse_bot")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateBotResponseBot {
   public static final String JSON_PROPERTY_BOT_TOKEN = "bot_token";
   private String botToken;
@@ -72,7 +72,7 @@ public class CreateBotResponseBot {
    * Get botToken
    * @return botToken
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -98,7 +98,7 @@ public class CreateBotResponseBot {
    * Get botProfileUrl
    * @return botProfileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class CreateBotResponseBot {
    * Get botUserid
    * @return botUserid
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT_USERID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -150,7 +150,7 @@ public class CreateBotResponseBot {
    * Get botNickname
    * @return botNickname
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -176,7 +176,7 @@ public class CreateBotResponseBot {
    * Get botType
    * @return botType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -202,7 +202,7 @@ public class CreateBotResponseBot {
    * Get botMetadata
    * @return botMetadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/CreateChannelMetacounterData.java
+++ b/src/main/java/org/openapitools/client/model/CreateChannelMetacounterData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   CreateChannelMetacounterData.JSON_PROPERTY_METACOUNTER
 })
 @JsonTypeName("createChannelMetacounterData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateChannelMetacounterData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;
@@ -60,7 +60,7 @@ public class CreateChannelMetacounterData {
    * Specifies the type of the channel. Either open_channels or group_channels.
    * @return channelType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the type of the channel. Either open_channels or group_channels.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class CreateChannelMetacounterData {
    * Specifies the URL of the channel to store the metacounter in.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to store the metacounter in.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class CreateChannelMetacounterData {
    * Specifies a &#x60;JSON&#x60; object that stores key-value items. The key must not have a comma (,) and its length is limited to 128 characters. The value must be an integer. This property can have up to 5 items.
    * @return metacounter
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a `JSON` object that stores key-value items. The key must not have a comma (,) and its length is limited to 128 characters. The value must be an integer. This property can have up to 5 items.")
   @JsonProperty(JSON_PROPERTY_METACOUNTER)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/CreateChannelMetadataData.java
+++ b/src/main/java/org/openapitools/client/model/CreateChannelMetadataData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   CreateChannelMetadataData.JSON_PROPERTY_INCLUDE_TS
 })
 @JsonTypeName("createChannelMetadataData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateChannelMetadataData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;
@@ -64,7 +64,7 @@ public class CreateChannelMetadataData {
    * Specifies the type of the channel. Either open_channels or group_channels.
    * @return channelType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the type of the channel. Either open_channels or group_channels.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -90,7 +90,7 @@ public class CreateChannelMetadataData {
    * Specifies the URL of the channel to store the metadata in.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to store the metadata in.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -116,7 +116,7 @@ public class CreateChannelMetadataData {
    * Specifies a &#x60;JSON&#x60; object that stores key-value items. The key must not have a comma (,) and its length is limited to 128 characters. The value must be a string and its length is limited to 190 characters. This property can have up to 5 items.
    * @return metadata
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a `JSON` object that stores key-value items. The key must not have a comma (,) and its length is limited to 128 characters. The value must be a string and its length is limited to 190 characters. This property can have up to 5 items.")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -142,7 +142,7 @@ public class CreateChannelMetadataData {
    * Determines whether to include the timestamp of when a metadata has been created in the response. (Default: false)
    * @return includeTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to include the timestamp of when a metadata has been created in the response. (Default: false)")
   @JsonProperty(JSON_PROPERTY_INCLUDE_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/CreateChannelMetadataResponse.java
+++ b/src/main/java/org/openapitools/client/model/CreateChannelMetadataResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   CreateChannelMetadataResponse.JSON_PROPERTY_INCLUDE_TS
 })
 @JsonTypeName("createChannelMetadataResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateChannelMetadataResponse {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   private Map<String, String> metadata = null;
@@ -68,7 +68,7 @@ public class CreateChannelMetadataResponse {
    * Get metadata
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class CreateChannelMetadataResponse {
    * Get includeTs
    * @return includeTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_INCLUDE_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/CreateUserData.java
+++ b/src/main/java/org/openapitools/client/model/CreateUserData.java
@@ -44,7 +44,7 @@ import org.sendbird.client.JSON;
   CreateUserData.JSON_PROPERTY_METADATA
 })
 @JsonTypeName("createUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateUserData {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -79,7 +79,7 @@ public class CreateUserData {
    * Specifies a user&#39;s unique ID, which is used to sign into the Sendbird service. The length is limited to 80 characters.&lt;br /&gt;&lt;br /&gt; Do not use PII (Personally Identifiable Information) of your service, such as user email address, legal name or phone number.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a user's unique ID, which is used to sign into the Sendbird service. The length is limited to 80 characters.<br /><br /> Do not use PII (Personally Identifiable Information) of your service, such as user email address, legal name or phone number.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -105,7 +105,7 @@ public class CreateUserData {
    * Specifies a nickname for a new user. The length is limited to 80 characters.
    * @return nickname
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a nickname for a new user. The length is limited to 80 characters.")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -131,7 +131,7 @@ public class CreateUserData {
    * Specifies the URL of the user&#39;s profile image. If left empty, no profile image is set for the user. The length is limited to 2,048 characters.&lt;br /&gt;&lt;br /&gt; The [domain filter](/docs/chat/v3/platform-api/guides/filter-and-moderation#2-domain-filter) filters out the request if the value of this property matches the filter&#39;s domain set.
    * @return profileUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the user's profile image. If left empty, no profile image is set for the user. The length is limited to 2,048 characters.<br /><br /> The [domain filter](/docs/chat/v3/platform-api/guides/filter-and-moderation#2-domain-filter) filters out the request if the value of this property matches the filter's domain set.")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -157,7 +157,7 @@ public class CreateUserData {
    * Uploads the file of the user&#39;s profile image. An acceptable image is limited to &#x60;JPG&#x60; (.jpg), &#x60;JPEG&#x60; (.jpeg), or &#x60;PNG&#x60; (.png) file of up to 25 MB.
    * @return profileFile
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Uploads the file of the user's profile image. An acceptable image is limited to `JPG` (.jpg), `JPEG` (.jpeg), or `PNG` (.png) file of up to 25 MB.")
   @JsonProperty(JSON_PROPERTY_PROFILE_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -183,7 +183,7 @@ public class CreateUserData {
    * Determines whether to create an access token for the user. If true, an opaque string token is issued and provided upon creation, which should be passed whenever the user logs in. If false, an access token is not required when the user logs in. (Default: false)
    * @return issueAccessToken
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to create an access token for the user. If true, an opaque string token is issued and provided upon creation, which should be passed whenever the user logs in. If false, an access token is not required when the user logs in. (Default: false)")
   @JsonProperty(JSON_PROPERTY_ISSUE_ACCESS_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -217,7 +217,7 @@ public class CreateUserData {
    * Specifies an array of unique keys of the user which is provided to Sendbird server for discovering friends. By using the keys, the server can identify and match the user with other users.
    * @return discoveryKeys
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of unique keys of the user which is provided to Sendbird server for discovering friends. By using the keys, the server can identify and match the user with other users.")
   @JsonProperty(JSON_PROPERTY_DISCOVERY_KEYS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -243,7 +243,7 @@ public class CreateUserData {
    * Specifies a &#x60;JSON&#x60; object to store key-value items for additional user information such as phone number, email or a long description of the user. The key must not have a comma (,) and its length is limited to 128 characters. The value must be a string and its length is limited to 190 characters. This property can have up to 5 items.
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies a `JSON` object to store key-value items for additional user information such as phone number, email or a long description of the user. The key must not have a comma (,) and its length is limited to 128 characters. The value must be a string and its length is limited to 190 characters. This property can have up to 5 items.")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/CreateUserMetadataData.java
+++ b/src/main/java/org/openapitools/client/model/CreateUserMetadataData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   CreateUserMetadataData.JSON_PROPERTY_METADATA
 })
 @JsonTypeName("createUserMetadataData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateUserMetadataData {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   private Object metadata;
@@ -52,7 +52,7 @@ public class CreateUserMetadataData {
    * Specifies a &#x60;JSON&#x60; object that stores key-value items. The key must not have a comma (,) and its length is limited to 128 characters. The value must be a string and its length is limited to 190 characters. This property can have up to 5 items.
    * @return metadata
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a `JSON` object that stores key-value items. The key must not have a comma (,) and its length is limited to 128 characters. The value must be a string and its length is limited to 190 characters. This property can have up to 5 items.")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/CreateUserMetadataResponse.java
+++ b/src/main/java/org/openapitools/client/model/CreateUserMetadataResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   CreateUserMetadataResponse.JSON_PROPERTY_ANY_OF
 })
 @JsonTypeName("createUserMetadataResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateUserMetadataResponse {
   public static final String JSON_PROPERTY_ANY_OF = "anyOf";
   private String anyOf;
@@ -52,7 +52,7 @@ public class CreateUserMetadataResponse {
    * Get anyOf
    * @return anyOf
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ANY_OF)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/CreateUserTokenData.java
+++ b/src/main/java/org/openapitools/client/model/CreateUserTokenData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   CreateUserTokenData.JSON_PROPERTY_EXPIRES_AT
 })
 @JsonTypeName("createUserTokenData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateUserTokenData {
   public static final String JSON_PROPERTY_EXPIRES_AT = "expires_at";
   private BigDecimal expiresAt;
@@ -53,7 +53,7 @@ public class CreateUserTokenData {
    * Specifies the expiration time of the new session token in Unix milliseconds format. By default, the expiration time of a session token is seven days from the timestamp when the token was issued.
    * @return expiresAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the expiration time of the new session token in Unix milliseconds format. By default, the expiration time of a session token is seven days from the timestamp when the token was issued.")
   @JsonProperty(JSON_PROPERTY_EXPIRES_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/CreateUserTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/CreateUserTokenResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   CreateUserTokenResponse.JSON_PROPERTY_EXPIRES_AT
 })
 @JsonTypeName("createUserTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CreateUserTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;
@@ -57,7 +57,7 @@ public class CreateUserTokenResponse {
    * Get token
    * @return token
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class CreateUserTokenResponse {
    * Get expiresAt
    * @return expiresAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EXPIRES_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/CustomTypeListBannedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/CustomTypeListBannedUsersResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   CustomTypeListBannedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("customTypeListBannedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class CustomTypeListBannedUsersResponse {
   public static final String JSON_PROPERTY_BANNED_LIST = "banned_list";
   private List<OcListBannedUsersResponseBannedListInner> bannedList = null;
@@ -67,7 +67,7 @@ public class CustomTypeListBannedUsersResponse {
    * Get bannedList
    * @return bannedList
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BANNED_LIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class CustomTypeListBannedUsersResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/DeleteAllowedIpsFromWhitelistResponse.java
+++ b/src/main/java/org/openapitools/client/model/DeleteAllowedIpsFromWhitelistResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   DeleteAllowedIpsFromWhitelistResponse.JSON_PROPERTY_IP_WHITELIST_ADDRESSES
 })
 @JsonTypeName("deleteAllowedIpsFromWhitelistResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class DeleteAllowedIpsFromWhitelistResponse {
   public static final String JSON_PROPERTY_IP_WHITELIST_ADDRESSES = "ip_whitelist_addresses";
   private List<String> ipWhitelistAddresses = null;
@@ -62,7 +62,7 @@ public class DeleteAllowedIpsFromWhitelistResponse {
    * Get ipWhitelistAddresses
    * @return ipWhitelistAddresses
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IP_WHITELIST_ADDRESSES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/DeleteApnsCertificateByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/DeleteApnsCertificateByIdResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   DeleteApnsCertificateByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("deleteApnsCertificateByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class DeleteApnsCertificateByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<String> pushConfigurations = null;
@@ -62,7 +62,7 @@ public class DeleteApnsCertificateByIdResponse {
    * Get pushConfigurations
    * @return pushConfigurations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_CONFIGURATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/EnableReactionsData.java
+++ b/src/main/java/org/openapitools/client/model/EnableReactionsData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   EnableReactionsData.JSON_PROPERTY_ENABLED
 })
 @JsonTypeName("enableReactionsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class EnableReactionsData {
   public static final String JSON_PROPERTY_ENABLED = "enabled";
   private Boolean enabled;
@@ -52,7 +52,7 @@ public class EnableReactionsData {
    * Determines whether to turn on the message reaction feature. (Default: false)
    * @return enabled
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to turn on the message reaction feature. (Default: false)")
   @JsonProperty(JSON_PROPERTY_ENABLED)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/EnableReactionsResponse.java
+++ b/src/main/java/org/openapitools/client/model/EnableReactionsResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   EnableReactionsResponse.JSON_PROPERTY_REACTIONS
 })
 @JsonTypeName("enableReactionsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class EnableReactionsResponse {
   public static final String JSON_PROPERTY_REACTIONS = "reactions";
   private Boolean reactions;
@@ -52,7 +52,7 @@ public class EnableReactionsResponse {
    * Get reactions
    * @return reactions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REACTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/Function.java
+++ b/src/main/java/org/openapitools/client/model/Function.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   Function.JSON_PROPERTY_LENGTH,
   Function.JSON_PROPERTY_PROTOTYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class Function {
   public static final String JSON_PROPERTY_ARGUMENTS = "arguments";
   private JsonNullable<Object> arguments = JsonNullable.<Object>of(null);
@@ -68,7 +68,7 @@ public class Function {
    * Get arguments
    * @return arguments
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -102,7 +102,7 @@ public class Function {
    * Get caller
    * @return caller
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CALLER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -128,7 +128,7 @@ public class Function {
    * Get length
    * @return length
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_LENGTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -154,7 +154,7 @@ public class Function {
    * Get prototype
    * @return prototype
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 

--- a/src/main/java/org/openapitools/client/model/GcAcceptInvitationData.java
+++ b/src/main/java/org/openapitools/client/model/GcAcceptInvitationData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcAcceptInvitationData.JSON_PROPERTY_ACCESS_CODE
 })
 @JsonTypeName("gcAcceptInvitationData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcAcceptInvitationData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -60,7 +60,7 @@ public class GcAcceptInvitationData {
    * Specifies the URL of the private group channel to join through accepting an invitation.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the private group channel to join through accepting an invitation.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class GcAcceptInvitationData {
    * Specifies the unique ID of the user to accept an invitation to join the private group channel.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the user to accept an invitation to join the private group channel.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class GcAcceptInvitationData {
    * This property should be specified if the private group channel to join requires an access code to the invited users, which means that the is_access_code_required property of the channel resource is true.
    * @return accessCode
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "This property should be specified if the private group channel to join requires an access code to the invited users, which means that the is_access_code_required property of the channel resource is true.")
   @JsonProperty(JSON_PROPERTY_ACCESS_CODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcBanUserData.java
+++ b/src/main/java/org/openapitools/client/model/GcBanUserData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcBanUserData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcBanUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcBanUserData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -68,7 +68,7 @@ public class GcBanUserData {
    * Specifies the URL of the channel where to ban a user.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel where to ban a user.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -94,7 +94,7 @@ public class GcBanUserData {
    * Specifies the unique ID of the user to ban.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the user to ban.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -120,7 +120,7 @@ public class GcBanUserData {
    * Specifies the ID of the agent (operator) who bans the user.
    * @return agentId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the agent (operator) who bans the user.")
   @JsonProperty(JSON_PROPERTY_AGENT_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -146,7 +146,7 @@ public class GcBanUserData {
    * Specifies the ban duration. If set to -1, the user will be banned permanently (10 years, technically). (Default: -1)
    * @return seconds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ban duration. If set to -1, the user will be banned permanently (10 years, technically). (Default: -1)")
   @JsonProperty(JSON_PROPERTY_SECONDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -172,7 +172,7 @@ public class GcBanUserData {
    * Specifies a reason for the banning. The length is limited to 250 characters.
    * @return description
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a reason for the banning. The length is limited to 250 characters.")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcBanUserResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcBanUserResponse.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   GcBanUserResponse.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("gcBanUserResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcBanUserResponse {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;
@@ -91,7 +91,7 @@ public class GcBanUserResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -117,7 +117,7 @@ public class GcBanUserResponse {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -143,7 +143,7 @@ public class GcBanUserResponse {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -169,7 +169,7 @@ public class GcBanUserResponse {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -195,7 +195,7 @@ public class GcBanUserResponse {
    * Get metadata
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -221,7 +221,7 @@ public class GcBanUserResponse {
    * Get nextUrl
    * @return nextUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -247,7 +247,7 @@ public class GcBanUserResponse {
    * Get nickname
    * @return nickname
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -273,7 +273,7 @@ public class GcBanUserResponse {
    * Get profileUrl
    * @return profileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -299,7 +299,7 @@ public class GcBanUserResponse {
    * Get requireAuthForProfileImage
    * @return requireAuthForProfileImage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -325,7 +325,7 @@ public class GcBanUserResponse {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcCheckIfMemberByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcCheckIfMemberByIdResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   GcCheckIfMemberByIdResponse.JSON_PROPERTY_STATE
 })
 @JsonTypeName("gcCheckIfMemberByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcCheckIfMemberByIdResponse {
   public static final String JSON_PROPERTY_IS_MEMBER = "is_member";
   private Boolean isMember;
@@ -56,7 +56,7 @@ public class GcCheckIfMemberByIdResponse {
    * Get isMember
    * @return isMember
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_MEMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -82,7 +82,7 @@ public class GcCheckIfMemberByIdResponse {
    * Get state
    * @return state
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcCreateChannelData.java
+++ b/src/main/java/org/openapitools/client/model/GcCreateChannelData.java
@@ -57,7 +57,7 @@ import org.sendbird.client.JSON;
   GcCreateChannelData.JSON_PROPERTY_BLOCK_SDK_USER_CHANNEL_JOIN
 })
 @JsonTypeName("gcCreateChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcCreateChannelData {
   public static final String JSON_PROPERTY_USER_IDS = "user_ids";
   private List<String> userIds = new ArrayList<>();
@@ -133,7 +133,7 @@ public class GcCreateChannelData {
    * Specifies an array of one or more IDs of users to invite to the channel. The maximum number of users to be invited at once is 100. The users below and this property can be used interchangeably.
    * @return userIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more IDs of users to invite to the channel. The maximum number of users to be invited at once is 100. The users below and this property can be used interchangeably.")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -167,7 +167,7 @@ public class GcCreateChannelData {
    * Specifies an array of one or more IDs of users to invite to the channel. The maximum number of users to be invited at once is 100. The user_ids above and this property can be used interchangeably.
    * @return users
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more IDs of users to invite to the channel. The maximum number of users to be invited at once is 100. The user_ids above and this property can be used interchangeably.")
   @JsonProperty(JSON_PROPERTY_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -193,7 +193,7 @@ public class GcCreateChannelData {
    * Specifies the name of the channel, or the channel topic. The length is limited to 191 characters. (Default: group channel)
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the name of the channel, or the channel topic. The length is limited to 191 characters. (Default: group channel)")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -219,7 +219,7 @@ public class GcCreateChannelData {
    * Specifies the URL of the channel. Only numbers, characters, and underscores are allowed. The length is 4 to 100 characters, inclusive. If not specified, a URL is automatically generated.
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the channel. Only numbers, characters, and underscores are allowed. The length is 4 to 100 characters, inclusive. If not specified, a URL is automatically generated.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -245,7 +245,7 @@ public class GcCreateChannelData {
    * Specifies the URL of the cover image for the channel. The length is limited to 2,048 characters.
    * @return coverUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the cover image for the channel. The length is limited to 2,048 characters.")
   @JsonProperty(JSON_PROPERTY_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -271,7 +271,7 @@ public class GcCreateChannelData {
    * Uploads the cover image file for the channel.
    * @return coverFile
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Uploads the cover image file for the channel.")
   @JsonProperty(JSON_PROPERTY_COVER_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -297,7 +297,7 @@ public class GcCreateChannelData {
    * Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.&lt;br /&gt;&lt;br /&gt; Custom types are also used within Sendbird&#39;s [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.<br /><br /> Custom types are also used within Sendbird's [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -323,7 +323,7 @@ public class GcCreateChannelData {
    * Specifies additional channel information such as a long description of the channel or &#x60;JSON&#x60; formatted string.
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional channel information such as a long description of the channel or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -349,7 +349,7 @@ public class GcCreateChannelData {
    * Determines whether to reuse an existing channel or create a new channel. If set to true, returns a channel with the same users in the user_ids or users property or creates a new channel if no match is found. Sendbird server can also use the custom channel type in the custom_type property if specified along with the users to return the corresponding channel. If set to false, Sendbird server always creates a new channel with a combination of the users as well as the channel custom type if specified. (Default: false)&lt;br /&gt;&lt;br /&gt; Under this property, Sendbird server does not distinguish channels based on other properties such as channel URL or channel name.
    * @return isDistinct
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to reuse an existing channel or create a new channel. If set to true, returns a channel with the same users in the user_ids or users property or creates a new channel if no match is found. Sendbird server can also use the custom channel type in the custom_type property if specified along with the users to return the corresponding channel. If set to false, Sendbird server always creates a new channel with a combination of the users as well as the channel custom type if specified. (Default: false)<br /><br /> Under this property, Sendbird server does not distinguish channels based on other properties such as channel URL or channel name.")
   @JsonProperty(JSON_PROPERTY_IS_DISTINCT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -375,7 +375,7 @@ public class GcCreateChannelData {
    * Determines whether to allow a user to join the channel without an invitation. (Default: false)
    * @return isPublic
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to allow a user to join the channel without an invitation. (Default: false)")
   @JsonProperty(JSON_PROPERTY_IS_PUBLIC)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -401,7 +401,7 @@ public class GcCreateChannelData {
    * Determines whether to allow the channel to accommodate more than 2,000 members. (Default: false) &lt;br/&gt;&lt;br/&gt; Supergroup channels are not supported with the is_distinct property and the property is false by default.
    * @return isSuper
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to allow the channel to accommodate more than 2,000 members. (Default: false) <br/><br/> Supergroup channels are not supported with the is_distinct property and the property is false by default.")
   @JsonProperty(JSON_PROPERTY_IS_SUPER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -427,7 +427,7 @@ public class GcCreateChannelData {
    * Determines whether to preserve the messages in the channel for the purpose of retrieving chat history. (Default: false)
    * @return isEphemeral
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to preserve the messages in the channel for the purpose of retrieving chat history. (Default: false)")
   @JsonProperty(JSON_PROPERTY_IS_EPHEMERAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -453,7 +453,7 @@ public class GcCreateChannelData {
    * This parameter can only be used when the channel operator creates a public group channel. They can set an access code for the corresponding type of channel. The channel then requires the specified access code to a user who attempts to join. If specified, the is_access_code_required property of the channel resource is set to true.
    * @return accessCode
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "This parameter can only be used when the channel operator creates a public group channel. They can set an access code for the corresponding type of channel. The channel then requires the specified access code to a user who attempts to join. If specified, the is_access_code_required property of the channel resource is set to true.")
   @JsonProperty(JSON_PROPERTY_ACCESS_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -479,7 +479,7 @@ public class GcCreateChannelData {
    * Specifies the ID of the user who has invited other users as members of the channel. The inviter is not automatically registered to the channel as a member, so you should specify the ID of the inviter in the user_ids property below if needed.
    * @return inviterId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the ID of the user who has invited other users as members of the channel. The inviter is not automatically registered to the channel as a member, so you should specify the ID of the inviter in the user_ids property below if needed.")
   @JsonProperty(JSON_PROPERTY_INVITER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -505,7 +505,7 @@ public class GcCreateChannelData {
    * Determines whether to receive a &#x60;400111&#x60; error and cease channel creation when there is at least one non-existing user in the specified user_ids or users property above. If set to false, the channel will be created excluding the non-existing users without receiving the mentioned error. (Default: false)
    * @return strict
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to receive a `400111` error and cease channel creation when there is at least one non-existing user in the specified user_ids or users property above. If set to false, the channel will be created excluding the non-existing users without receiving the mentioned error. (Default: false)")
   @JsonProperty(JSON_PROPERTY_STRICT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -531,7 +531,7 @@ public class GcCreateChannelData {
    * Specifies one or more key-value pair items which set the invitation status of each user invited to the channel. The key should be a user_id and the value should be their joining status. Acceptable values are joined, invited_by_friend, and invited_by_non_friend. (Default: joined)
    * @return invitationStatus
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies one or more key-value pair items which set the invitation status of each user invited to the channel. The key should be a user_id and the value should be their joining status. Acceptable values are joined, invited_by_friend, and invited_by_non_friend. (Default: joined)")
   @JsonProperty(JSON_PROPERTY_INVITATION_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -557,7 +557,7 @@ public class GcCreateChannelData {
    * Specifies one or more key-value pair items which set the channel&#39;s hidden status for each user. The key should be a user_id and the value should be their hidden status. Acceptable values are limited to the following:&lt;br /&gt;- unhidden (default): the channel is included in when retrieving a list of group channels.&lt;br /&gt;- hidden_allow_auto_unhide: the channel automatically gets unhidden when receiving a new message.&lt;br /&gt;- hidden_prevent_auto_unhide: the channel keeps hidden though receiving a new message.
    * @return hiddenStatus
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies one or more key-value pair items which set the channel's hidden status for each user. The key should be a user_id and the value should be their hidden status. Acceptable values are limited to the following:<br />- unhidden (default): the channel is included in when retrieving a list of group channels.<br />- hidden_allow_auto_unhide: the channel automatically gets unhidden when receiving a new message.<br />- hidden_prevent_auto_unhide: the channel keeps hidden though receiving a new message.")
   @JsonProperty(JSON_PROPERTY_HIDDEN_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -591,7 +591,7 @@ public class GcCreateChannelData {
    * Specifies an array of one or more IDs of users to register as operators of the channel. You should also include these IDs in the user_ids property to invite them to the channel as members. They can delete any messages in the channel, and also view all messages without any filtering or throttling. The maximum allowed number of operators per channel is 100.
    * @return operatorIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more IDs of users to register as operators of the channel. You should also include these IDs in the user_ids property to invite them to the channel as members. They can delete any messages in the channel, and also view all messages without any filtering or throttling. The maximum allowed number of operators per channel is 100.")
   @JsonProperty(JSON_PROPERTY_OPERATOR_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -617,7 +617,7 @@ public class GcCreateChannelData {
    * Determines whether to block users from joining the channel through the Chat SDK. This parameter can be used in order to restrict the ways for users to join the channel, and only using the [join a channel](#2-join-a-channel) action can add a user to the channel. (Default: false)
    * @return blockSdkUserChannelJoin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to block users from joining the channel through the Chat SDK. This parameter can be used in order to restrict the ways for users to join the channel, and only using the [join a channel](#2-join-a-channel) action can add a user to the channel. (Default: false)")
   @JsonProperty(JSON_PROPERTY_BLOCK_SDK_USER_CHANNEL_JOIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcDeclineInvitationData.java
+++ b/src/main/java/org/openapitools/client/model/GcDeclineInvitationData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   GcDeclineInvitationData.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("gcDeclineInvitationData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcDeclineInvitationData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -56,7 +56,7 @@ public class GcDeclineInvitationData {
    * Specifies the URL of the private group channel to decline an invitation from.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the private group channel to decline an invitation from.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -82,7 +82,7 @@ public class GcDeclineInvitationData {
    * Specifies the unique ID of the user to decline an invitation.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the user to decline an invitation.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcFreezeChannelData.java
+++ b/src/main/java/org/openapitools/client/model/GcFreezeChannelData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   GcFreezeChannelData.JSON_PROPERTY_FREEZE
 })
 @JsonTypeName("gcFreezeChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcFreezeChannelData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -56,7 +56,7 @@ public class GcFreezeChannelData {
    * Specifies the URL of the channel to freeze.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to freeze.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -82,7 +82,7 @@ public class GcFreezeChannelData {
    * Determines whether to freeze the channel. (Default: false)
    * @return freeze
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to freeze the channel. (Default: false)")
   @JsonProperty(JSON_PROPERTY_FREEZE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcHideOrArchiveChannelData.java
+++ b/src/main/java/org/openapitools/client/model/GcHideOrArchiveChannelData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcHideOrArchiveChannelData.JSON_PROPERTY_HIDE_PREVIOUS_MESSAGES
 })
 @JsonTypeName("gcHideOrArchiveChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcHideOrArchiveChannelData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -68,7 +68,7 @@ public class GcHideOrArchiveChannelData {
    * Specifies the URL of the channel to hide or archive.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to hide or archive.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -94,7 +94,7 @@ public class GcHideOrArchiveChannelData {
    * Specifies the unique ID of the user whose channel will be hidden or archived from the list. This property is required when should_hide_all is set to false, which is the default value. However, when should_hide_all is set to true, this property isn&#39;t effective.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the user whose channel will be hidden or archived from the list. This property is required when should_hide_all is set to false, which is the default value. However, when should_hide_all is set to true, this property isn't effective.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -120,7 +120,7 @@ public class GcHideOrArchiveChannelData {
    * Determines the state and operating behavior of the channel in a channel list. If set to true, the channel is hidden from a user&#39;s channel list but it will reappear when there is a new message. If set to false, the channel is hidden from a user&#39;s channel list and it will remain hidden unless the value of the property changes to true through [unarchiving](#2-unhide-or-unarchive-a-channel). (Default: true)&lt;br /&gt;&lt;br /&gt; When a user who has hidden the channel sends a message in that channel through the [Platform API](/docs/chat/v3/platform-api/guides/messages#2-send-a-message), the &#x60;allow_auto_unhide&#x60; property is changed to true, making the channel reappear in the channel list.
    * @return allowAutoUnhide
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines the state and operating behavior of the channel in a channel list. If set to true, the channel is hidden from a user's channel list but it will reappear when there is a new message. If set to false, the channel is hidden from a user's channel list and it will remain hidden unless the value of the property changes to true through [unarchiving](#2-unhide-or-unarchive-a-channel). (Default: true)<br /><br /> When a user who has hidden the channel sends a message in that channel through the [Platform API](/docs/chat/v3/platform-api/guides/messages#2-send-a-message), the `allow_auto_unhide` property is changed to true, making the channel reappear in the channel list.")
   @JsonProperty(JSON_PROPERTY_ALLOW_AUTO_UNHIDE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -146,7 +146,7 @@ public class GcHideOrArchiveChannelData {
    * Determines whether to make the specified channel disappear from the channel list of all channel members. When this is set to true, the user_id property isn&#39;t effective and doesn&#39;t need to be specified in the request. (Default: false)
    * @return shouldHideAll
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to make the specified channel disappear from the channel list of all channel members. When this is set to true, the user_id property isn't effective and doesn't need to be specified in the request. (Default: false)")
   @JsonProperty(JSON_PROPERTY_SHOULD_HIDE_ALL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -172,7 +172,7 @@ public class GcHideOrArchiveChannelData {
    * When the channel gets appeared back in either the list of the user in the user_id property or the lists of all channel members (should_hide_all &#x3D; true), determines whether to conceal the messages sent and received before hiding or archiving the channel. (Default: false)&lt;br /&gt;&lt;br /&gt; This property is effective only when the value of the [global application settings resource](/docs/chat/v3/platform-api/guides/global-application-settings#-3-resource-representation)&#39;s display_past_message property is false.
    * @return hidePreviousMessages
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "When the channel gets appeared back in either the list of the user in the user_id property or the lists of all channel members (should_hide_all = true), determines whether to conceal the messages sent and received before hiding or archiving the channel. (Default: false)<br /><br /> This property is effective only when the value of the [global application settings resource](/docs/chat/v3/platform-api/guides/global-application-settings#-3-resource-representation)'s display_past_message property is false.")
   @JsonProperty(JSON_PROPERTY_HIDE_PREVIOUS_MESSAGES)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcInviteAsMembersData.java
+++ b/src/main/java/org/openapitools/client/model/GcInviteAsMembersData.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   GcInviteAsMembersData.JSON_PROPERTY_HIDDEN_STATUS
 })
 @JsonTypeName("gcInviteAsMembersData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcInviteAsMembersData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -70,7 +70,7 @@ public class GcInviteAsMembersData {
    * Specifies the URL of the channel to invite into.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to invite into.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -101,7 +101,7 @@ public class GcInviteAsMembersData {
    * Specifies an array of one or more user IDs to invite into the channel. The maximum number of users to be invited at once is 100. The users can be used instead of this property.
    * @return userIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more user IDs to invite into the channel. The maximum number of users to be invited at once is 100. The users can be used instead of this property.")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -132,7 +132,7 @@ public class GcInviteAsMembersData {
    * Specifies a list of one or more &#x60;JSON&#x60; objects which contain the user_id property to invite into the channel. The maximum number of users to be invited at once is 100. The user_ids can be used instead of this property.
    * @return users
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a list of one or more `JSON` objects which contain the user_id property to invite into the channel. The maximum number of users to be invited at once is 100. The user_ids can be used instead of this property.")
   @JsonProperty(JSON_PROPERTY_USERS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -158,7 +158,7 @@ public class GcInviteAsMembersData {
    * Specifies one or more key-value pair items which set the invitation status of each user invited to the channel. The key should be a user_id and the value should be their joining status. Acceptable values are joined, invited_by_friend, and invited_by_non_friend. (Default: joined)
    * @return invitationStatus
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies one or more key-value pair items which set the invitation status of each user invited to the channel. The key should be a user_id and the value should be their joining status. Acceptable values are joined, invited_by_friend, and invited_by_non_friend. (Default: joined)")
   @JsonProperty(JSON_PROPERTY_INVITATION_STATUS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -184,7 +184,7 @@ public class GcInviteAsMembersData {
    * Specifies one or more key-value pair items which set the channel&#39;s hidden status for each user. The key should be a user_id and the value should be their hidden status. Acceptable values are limited to the following:&lt;br /&gt;- unhidden (default): the channel is included in when retrieving a list of group channels.&lt;br /&gt;- hidden_allow_auto_unhide: the channel automatically gets unhidden when receiving a new message.&lt;br /&gt;- hidden_prevent_auto_unhide: the channel keeps hidden though receiving a new message.
    * @return hiddenStatus
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies one or more key-value pair items which set the channel's hidden status for each user. The key should be a user_id and the value should be their hidden status. Acceptable values are limited to the following:<br />- unhidden (default): the channel is included in when retrieving a list of group channels.<br />- hidden_allow_auto_unhide: the channel automatically gets unhidden when receiving a new message.<br />- hidden_prevent_auto_unhide: the channel keeps hidden though receiving a new message.")
   @JsonProperty(JSON_PROPERTY_HIDDEN_STATUS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcJoinChannelData.java
+++ b/src/main/java/org/openapitools/client/model/GcJoinChannelData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcJoinChannelData.JSON_PROPERTY_ACCESS_CODE
 })
 @JsonTypeName("gcJoinChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcJoinChannelData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -60,7 +60,7 @@ public class GcJoinChannelData {
    * Specifies the URL of the channel to join.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to join.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class GcJoinChannelData {
    * Specifies the unique ID of the user to join the public group channel.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the user to join the public group channel.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class GcJoinChannelData {
    * This property should be specified if the public group channel to join requires an access code to users, which means that the is_access_code_required property of the channel resource is true.
    * @return accessCode
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "This property should be specified if the public group channel to join requires an access code to users, which means that the is_access_code_required property of the channel resource is true.")
   @JsonProperty(JSON_PROPERTY_ACCESS_CODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcLeaveChannelData.java
+++ b/src/main/java/org/openapitools/client/model/GcLeaveChannelData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcLeaveChannelData.JSON_PROPERTY_SHOULD_LEAVE_ALL
 })
 @JsonTypeName("gcLeaveChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcLeaveChannelData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -62,7 +62,7 @@ public class GcLeaveChannelData {
    * Specifies the URL of the channel to leave.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to leave.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -93,7 +93,7 @@ public class GcLeaveChannelData {
    * Specifies an array of one or more IDs of the users to leave the channel.
    * @return userIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more IDs of the users to leave the channel.")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -119,7 +119,7 @@ public class GcLeaveChannelData {
    * Determines whether to make all members leave the channel. (Default: false)
    * @return shouldLeaveAll
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to make all members leave the channel. (Default: false)")
   @JsonProperty(JSON_PROPERTY_SHOULD_LEAVE_ALL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcListBannedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcListBannedUsersResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   GcListBannedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("gcListBannedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcListBannedUsersResponse {
   public static final String JSON_PROPERTY_BANNED_LIST = "banned_list";
   private List<OcListBannedUsersResponseBannedListInner> bannedList = null;
@@ -72,7 +72,7 @@ public class GcListBannedUsersResponse {
    * Get bannedList
    * @return bannedList
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BANNED_LIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -98,7 +98,7 @@ public class GcListBannedUsersResponse {
    * Get totalBanCount
    * @return totalBanCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOTAL_BAN_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class GcListBannedUsersResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcListChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcListChannelsResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   GcListChannelsResponse.JSON_PROPERTY_TS
 })
 @JsonTypeName("gcListChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcListChannelsResponse {
   public static final String JSON_PROPERTY_CHANNELS = "channels";
   private List<SendBirdGroupChannel> channels = null;
@@ -72,7 +72,7 @@ public class GcListChannelsResponse {
    * Get channels
    * @return channels
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNELS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -98,7 +98,7 @@ public class GcListChannelsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class GcListChannelsResponse {
    * Get ts
    * @return ts
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcListMembersResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcListMembersResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcListMembersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("gcListMembersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcListMembersResponse {
   public static final String JSON_PROPERTY_MEMBERS = "members";
   private List<SendBirdUser> members = null;
@@ -67,7 +67,7 @@ public class GcListMembersResponse {
    * Get members
    * @return members
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MEMBERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class GcListMembersResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcListMutedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcListMutedUsersResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   GcListMutedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("gcListMutedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcListMutedUsersResponse {
   public static final String JSON_PROPERTY_MUTED_LIST = "muted_list";
   private List<SendBirdUser> mutedList = null;
@@ -72,7 +72,7 @@ public class GcListMutedUsersResponse {
    * Get mutedList
    * @return mutedList
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MUTED_LIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -98,7 +98,7 @@ public class GcListMutedUsersResponse {
    * Get totalMuteCount
    * @return totalMuteCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOTAL_MUTE_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class GcListMutedUsersResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcListOperatorsResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcListOperatorsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcListOperatorsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("gcListOperatorsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcListOperatorsResponse {
   public static final String JSON_PROPERTY_OPERATORS = "operators";
   private List<SendBirdUser> operators = null;
@@ -67,7 +67,7 @@ public class GcListOperatorsResponse {
    * Get operators
    * @return operators
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPERATORS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class GcListOperatorsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsDeliveredData.java
+++ b/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsDeliveredData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcMarkAllMessagesAsDeliveredData.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("gcMarkAllMessagesAsDeliveredData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcMarkAllMessagesAsDeliveredData {
   public static final String JSON_PROPERTY_APPLICATION_ID = "application_id";
   private String applicationId;
@@ -60,7 +60,7 @@ public class GcMarkAllMessagesAsDeliveredData {
    * Specifies the unique ID of your application.
    * @return applicationId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of your application.")
   @JsonProperty(JSON_PROPERTY_APPLICATION_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class GcMarkAllMessagesAsDeliveredData {
    * Specifies the URL of the target channel.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the target channel.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class GcMarkAllMessagesAsDeliveredData {
    * Specifies the ID of the recipient to mark messages as delivered.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the recipient to mark messages as delivered.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsDeliveredResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsDeliveredResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   GcMarkAllMessagesAsDeliveredResponse.JSON_PROPERTY_TS
 })
 @JsonTypeName("gcMarkAllMessagesAsDeliveredResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcMarkAllMessagesAsDeliveredResponse {
   public static final String JSON_PROPERTY_TS = "ts";
   private BigDecimal ts;
@@ -53,7 +53,7 @@ public class GcMarkAllMessagesAsDeliveredResponse {
    * Get ts
    * @return ts
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsReadData.java
+++ b/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsReadData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcMarkAllMessagesAsReadData.JSON_PROPERTY_TIMESTAMP
 })
 @JsonTypeName("gcMarkAllMessagesAsReadData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcMarkAllMessagesAsReadData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -60,7 +60,7 @@ public class GcMarkAllMessagesAsReadData {
    * Specifies the URL of the target channel.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the target channel.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class GcMarkAllMessagesAsReadData {
    * Specifies the ID of the user to mark all messages as read.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the user to mark all messages as read.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class GcMarkAllMessagesAsReadData {
    * Specifies the timestamp to be the reference point of marking as read. If specified, the messages received before the specified time are marked as read.
    * @return timestamp
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the timestamp to be the reference point of marking as read. If specified, the messages received before the specified time are marked as read.")
   @JsonProperty(JSON_PROPERTY_TIMESTAMP)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcMuteUserData.java
+++ b/src/main/java/org/openapitools/client/model/GcMuteUserData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   GcMuteUserData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcMuteUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcMuteUserData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -64,7 +64,7 @@ public class GcMuteUserData {
    * Specifies the URL of the target channel.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the target channel.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -90,7 +90,7 @@ public class GcMuteUserData {
    * Specifies the ID of the target user to mute.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the target user to mute.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -116,7 +116,7 @@ public class GcMuteUserData {
    * Specifies the duration of mute status. If set to -1, the user will be muted permanently (10 years, technically). (Default: -1)
    * @return seconds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the duration of mute status. If set to -1, the user will be muted permanently (10 years, technically). (Default: -1)")
   @JsonProperty(JSON_PROPERTY_SECONDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -142,7 +142,7 @@ public class GcMuteUserData {
    * Specifies a reason for the muting.
    * @return description
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a reason for the muting.")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcRegisterOperatorsData.java
+++ b/src/main/java/org/openapitools/client/model/GcRegisterOperatorsData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   GcRegisterOperatorsData.JSON_PROPERTY_OPERATOR_IDS
 })
 @JsonTypeName("gcRegisterOperatorsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcRegisterOperatorsData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -58,7 +58,7 @@ public class GcRegisterOperatorsData {
    * Specifies the URL of the channel to register operators to.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to register operators to.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -89,7 +89,7 @@ public class GcRegisterOperatorsData {
    * Specifies an array of one or more IDs of users to register as operators of the channel. If the operators are not members of the channel yet, they need an [invitation](#2-invite-as-members) to [join](#2-join-a-channel) a privte group channel while they don&#39;t need any to join a [public](#-3-private-vs-public) group channel. The maximum allowed number of operators per channel is 100.
    * @return operatorIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more IDs of users to register as operators of the channel. If the operators are not members of the channel yet, they need an [invitation](#2-invite-as-members) to [join](#2-join-a-channel) a privte group channel while they don't need any to join a [public](#-3-private-vs-public) group channel. The maximum allowed number of operators per channel is 100.")
   @JsonProperty(JSON_PROPERTY_OPERATOR_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcRegisterOperatorsResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcRegisterOperatorsResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcRegisterOperatorsResponse.JSON_PROPERTY_OPERATOR_IDS
 })
 @JsonTypeName("gcRegisterOperatorsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcRegisterOperatorsResponse {
   public static final String JSON_PROPERTY_OPERATOR_IDS = "operator_ids";
   private List<String> operatorIds = null;
@@ -62,7 +62,7 @@ public class GcRegisterOperatorsResponse {
    * Get operatorIds
    * @return operatorIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPERATOR_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcResetChatHistoryData.java
+++ b/src/main/java/org/openapitools/client/model/GcResetChatHistoryData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcResetChatHistoryData.JSON_PROPERTY_RESET_ALL
 })
 @JsonTypeName("gcResetChatHistoryData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcResetChatHistoryData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -60,7 +60,7 @@ public class GcResetChatHistoryData {
    * Specifies the URL of the target channel to reset chat history.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the target channel to reset chat history.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class GcResetChatHistoryData {
    * Specifies the unique ID of the user whose chat history to reset in the channel. If this user_id property is specified, the reset_all property is not required.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the user whose chat history to reset in the channel. If this user_id property is specified, the reset_all property is not required.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class GcResetChatHistoryData {
    * Determines whether to reset all users&#39; chat history in the channel. If this reset_all property is specified, the user_id property is not required.
    * @return resetAll
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to reset all users' chat history in the channel. If this reset_all property is specified, the user_id property is not required.")
   @JsonProperty(JSON_PROPERTY_RESET_ALL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcResetChatHistoryResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcResetChatHistoryResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   GcResetChatHistoryResponse.JSON_PROPERTY_TS_MESSAGE_OFFSET
 })
 @JsonTypeName("gcResetChatHistoryResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcResetChatHistoryResponse {
   public static final String JSON_PROPERTY_TS_MESSAGE_OFFSET = "ts_message_offset";
   private BigDecimal tsMessageOffset;
@@ -53,7 +53,7 @@ public class GcResetChatHistoryResponse {
    * Get tsMessageOffset
    * @return tsMessageOffset
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TS_MESSAGE_OFFSET)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcTypingIndicatorsData.java
+++ b/src/main/java/org/openapitools/client/model/GcTypingIndicatorsData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcTypingIndicatorsData.JSON_PROPERTY_USER_IDS
 })
 @JsonTypeName("gcTypingIndicatorsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcTypingIndicatorsData {
   public static final String JSON_PROPERTY_USER_IDS = "user_ids";
   private List<String> userIds = new ArrayList<>();
@@ -59,7 +59,7 @@ public class GcTypingIndicatorsData {
    * Specifies an array of IDs of users who are to stop using the typing indicator. You can list up to ten user IDs.
    * @return userIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of IDs of users who are to stop using the typing indicator. You can list up to ten user IDs.")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcUpdateBanByIdData.java
+++ b/src/main/java/org/openapitools/client/model/GcUpdateBanByIdData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   GcUpdateBanByIdData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcUpdateBanByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcUpdateBanByIdData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -64,7 +64,7 @@ public class GcUpdateBanByIdData {
    * Specifies the URL of the target channel.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the target channel.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -90,7 +90,7 @@ public class GcUpdateBanByIdData {
    * Specifies the ID of the banned user to update.
    * @return bannedUserId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the banned user to update.")
   @JsonProperty(JSON_PROPERTY_BANNED_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -116,7 +116,7 @@ public class GcUpdateBanByIdData {
    * Specifies a new ban duration to update. If set to -1, the user will be banned permanently (10 years, technically).
    * @return seconds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a new ban duration to update. If set to -1, the user will be banned permanently (10 years, technically).")
   @JsonProperty(JSON_PROPERTY_SECONDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -142,7 +142,7 @@ public class GcUpdateBanByIdData {
    * Specifies a new reason for the banning to update. The length is limited to 250 characters.
    * @return description
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a new reason for the banning to update. The length is limited to 250 characters.")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcUpdateBanByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcUpdateBanByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GcUpdateBanByIdResponse.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcUpdateBanByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcUpdateBanByIdResponse {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;
@@ -66,7 +66,7 @@ public class GcUpdateBanByIdResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class GcUpdateBanByIdResponse {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -118,7 +118,7 @@ public class GcUpdateBanByIdResponse {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -144,7 +144,7 @@ public class GcUpdateBanByIdResponse {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcUpdateChannelByUrlData.java
+++ b/src/main/java/org/openapitools/client/model/GcUpdateChannelByUrlData.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   GcUpdateChannelByUrlData.JSON_PROPERTY_OPERATOR_IDS
 })
 @JsonTypeName("gcUpdateChannelByUrlData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcUpdateChannelByUrlData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -91,7 +91,7 @@ public class GcUpdateChannelByUrlData {
    * Specifies the URL of the channel to update.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to update.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -117,7 +117,7 @@ public class GcUpdateChannelByUrlData {
    * Specifies the name of the channel, or the channel topic. The length is limited to 191 characters.
    * @return name
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the name of the channel, or the channel topic. The length is limited to 191 characters.")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -143,7 +143,7 @@ public class GcUpdateChannelByUrlData {
    * Specifies the unique URL of the cover image. The length is limited to 2,048 characters.
    * @return coverUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique URL of the cover image. The length is limited to 2,048 characters.")
   @JsonProperty(JSON_PROPERTY_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -169,7 +169,7 @@ public class GcUpdateChannelByUrlData {
    * Uploads the cover image file for the channel.
    * @return coverFile
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Uploads the cover image file for the channel.")
   @JsonProperty(JSON_PROPERTY_COVER_FILE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -195,7 +195,7 @@ public class GcUpdateChannelByUrlData {
    * Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.&lt;br /&gt;&lt;br /&gt; Custom types are also used within Sendbird&#39;s [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.
    * @return customType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.<br /><br /> Custom types are also used within Sendbird's [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -221,7 +221,7 @@ public class GcUpdateChannelByUrlData {
    * Specifies additional channel information such as a long description of the channel or &#x60;JSON&#x60; formatted string.
    * @return data
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies additional channel information such as a long description of the channel or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -247,7 +247,7 @@ public class GcUpdateChannelByUrlData {
    * Determines whether to reuse an existing channel or create a new channel. If set to true, returns a channel with the current channel members users or creates a new channel if no match is found. Sendbird server can also use the custom channel type in the custom_type property if specified along with the users to return the corresponding channel. If set to false, Sendbird server always creates a new channel with a combination of the users as well as the channel custom type if specified. (Default: false)&lt;br /&gt;&lt;br /&gt; Under this property, Sendbird server does not distinguish channels based on other properties such as channel URL or channel name.
    * @return isDistinct
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to reuse an existing channel or create a new channel. If set to true, returns a channel with the current channel members users or creates a new channel if no match is found. Sendbird server can also use the custom channel type in the custom_type property if specified along with the users to return the corresponding channel. If set to false, Sendbird server always creates a new channel with a combination of the users as well as the channel custom type if specified. (Default: false)<br /><br /> Under this property, Sendbird server does not distinguish channels based on other properties such as channel URL or channel name.")
   @JsonProperty(JSON_PROPERTY_IS_DISTINCT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -273,7 +273,7 @@ public class GcUpdateChannelByUrlData {
    * Determines whether to allow a user to join the channel without an invitation. (Default: false)
    * @return isPublic
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to allow a user to join the channel without an invitation. (Default: false)")
   @JsonProperty(JSON_PROPERTY_IS_PUBLIC)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -299,7 +299,7 @@ public class GcUpdateChannelByUrlData {
    * This property can be used only when the channel operator wants to set an access code for a public group channel. If specified, the is_access_code_required property of the channel resource is then set to true, and the channel begins to require the specified access code to a user who attempts to join.
    * @return accessCode
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "This property can be used only when the channel operator wants to set an access code for a public group channel. If specified, the is_access_code_required property of the channel resource is then set to true, and the channel begins to require the specified access code to a user who attempts to join.")
   @JsonProperty(JSON_PROPERTY_ACCESS_CODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -330,7 +330,7 @@ public class GcUpdateChannelByUrlData {
    * Specifies an array of one or more IDs of users to register as operators of the channel. If the operators are not members of the channel yet, they need an [invitation](#2-invite-as-members) to [join](#2-join-a-channel) a privte group channel while they don&#39;t need any to join a [public](#-3-private-vs-public) group channel. The maximum allowed number of operators per channel is 100.
    * @return operatorIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more IDs of users to register as operators of the channel. If the operators are not members of the channel yet, they need an [invitation](#2-invite-as-members) to [join](#2-join-a-channel) a privte group channel while they don't need any to join a [public](#-3-private-vs-public) group channel. The maximum allowed number of operators per channel is 100.")
   @JsonProperty(JSON_PROPERTY_OPERATOR_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GcViewBanByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcViewBanByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GcViewBanByIdResponse.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcViewBanByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcViewBanByIdResponse {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;
@@ -66,7 +66,7 @@ public class GcViewBanByIdResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class GcViewBanByIdResponse {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -118,7 +118,7 @@ public class GcViewBanByIdResponse {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -144,7 +144,7 @@ public class GcViewBanByIdResponse {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcViewMuteByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcViewMuteByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GcViewMuteByIdResponse.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcViewMuteByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcViewMuteByIdResponse {
   public static final String JSON_PROPERTY_IS_MUTED = "is_muted";
   private Boolean isMuted;
@@ -69,7 +69,7 @@ public class GcViewMuteByIdResponse {
    * Get isMuted
    * @return isMuted
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_MUTED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -95,7 +95,7 @@ public class GcViewMuteByIdResponse {
    * Get remainingDuration
    * @return remainingDuration
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REMAINING_DURATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -121,7 +121,7 @@ public class GcViewMuteByIdResponse {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -147,7 +147,7 @@ public class GcViewMuteByIdResponse {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -173,7 +173,7 @@ public class GcViewMuteByIdResponse {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GcViewNumberOfEachMembersUnreadMessagesResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcViewNumberOfEachMembersUnreadMessagesResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcViewNumberOfEachMembersUnreadMessagesResponse.JSON_PROPERTY_UNREAD
 })
 @JsonTypeName("gcViewNumberOfEachMembersUnreadMessagesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GcViewNumberOfEachMembersUnreadMessagesResponse {
   public static final String JSON_PROPERTY_UNREAD = "unread";
   private Map<String, BigDecimal> unread = null;
@@ -64,7 +64,7 @@ public class GcViewNumberOfEachMembersUnreadMessagesResponse {
    * Get unread
    * @return unread
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNREAD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GenerateSecondaryApiTokenData.java
+++ b/src/main/java/org/openapitools/client/model/GenerateSecondaryApiTokenData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   GenerateSecondaryApiTokenData.JSON_PROPERTY_H_T_T_P_A_P_I_T_O_K_E_N
 })
 @JsonTypeName("generateSecondaryApiTokenData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GenerateSecondaryApiTokenData {
   public static final String JSON_PROPERTY_H_T_T_P_A_P_I_T_O_K_E_N = "HTTP_API_TOKEN";
   private String HTTP_API_TOKEN;
@@ -52,7 +52,7 @@ public class GenerateSecondaryApiTokenData {
    * Specifies the master API token of the application.
    * @return HTTP_API_TOKEN
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the master API token of the application.")
   @JsonProperty(JSON_PROPERTY_H_T_T_P_A_P_I_T_O_K_E_N)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/GenerateSecondaryApiTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/GenerateSecondaryApiTokenResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GenerateSecondaryApiTokenResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("generateSecondaryApiTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GenerateSecondaryApiTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;
@@ -57,7 +57,7 @@ public class GenerateSecondaryApiTokenResponse {
    * Get token
    * @return token
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class GenerateSecondaryApiTokenResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GetDetailedOpenRateOfAnnouncementByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetDetailedOpenRateOfAnnouncementByIdResponse.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   GetDetailedOpenRateOfAnnouncementByIdResponse.JSON_PROPERTY_CUMULATIVE_OPEN_RATES
 })
 @JsonTypeName("getDetailedOpenRateOfAnnouncementByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GetDetailedOpenRateOfAnnouncementByIdResponse {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;
@@ -71,7 +71,7 @@ public class GetDetailedOpenRateOfAnnouncementByIdResponse {
    * Get uniqueId
    * @return uniqueId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNIQUE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -105,7 +105,7 @@ public class GetDetailedOpenRateOfAnnouncementByIdResponse {
    * Get openCounts
    * @return openCounts
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_COUNTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -139,7 +139,7 @@ public class GetDetailedOpenRateOfAnnouncementByIdResponse {
    * Get openRates
    * @return openRates
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_RATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -173,7 +173,7 @@ public class GetDetailedOpenRateOfAnnouncementByIdResponse {
    * Get cumulativeOpenCounts
    * @return cumulativeOpenCounts
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUMULATIVE_OPEN_COUNTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -207,7 +207,7 @@ public class GetDetailedOpenRateOfAnnouncementByIdResponse {
    * Get cumulativeOpenRates
    * @return cumulativeOpenRates
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUMULATIVE_OPEN_RATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GetDetailedOpenRateOfAnnouncementGroupResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetDetailedOpenRateOfAnnouncementGroupResponse.java
@@ -43,7 +43,7 @@ import org.sendbird.client.JSON;
   GetDetailedOpenRateOfAnnouncementGroupResponse.JSON_PROPERTY_CUMULATIVE_OPEN_RATES
 })
 @JsonTypeName("getDetailedOpenRateOfAnnouncementGroupResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GetDetailedOpenRateOfAnnouncementGroupResponse {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;
@@ -75,7 +75,7 @@ public class GetDetailedOpenRateOfAnnouncementGroupResponse {
    * Get uniqueId
    * @return uniqueId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNIQUE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -101,7 +101,7 @@ public class GetDetailedOpenRateOfAnnouncementGroupResponse {
    * Get announcementGroup
    * @return announcementGroup
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ANNOUNCEMENT_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -135,7 +135,7 @@ public class GetDetailedOpenRateOfAnnouncementGroupResponse {
    * Get openCounts
    * @return openCounts
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_COUNTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -169,7 +169,7 @@ public class GetDetailedOpenRateOfAnnouncementGroupResponse {
    * Get openRates
    * @return openRates
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_RATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -203,7 +203,7 @@ public class GetDetailedOpenRateOfAnnouncementGroupResponse {
    * Get cumulativeOpenCounts
    * @return cumulativeOpenCounts
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUMULATIVE_OPEN_COUNTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -237,7 +237,7 @@ public class GetDetailedOpenRateOfAnnouncementGroupResponse {
    * Get cumulativeOpenRates
    * @return cumulativeOpenRates
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUMULATIVE_OPEN_RATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GetDetailedOpenStatusOfAnnouncementByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetDetailedOpenStatusOfAnnouncementByIdResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GetDetailedOpenStatusOfAnnouncementByIdResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("getDetailedOpenStatusOfAnnouncementByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GetDetailedOpenStatusOfAnnouncementByIdResponse {
   public static final String JSON_PROPERTY_OPEN_STATUS = "open_status";
   private List<GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner> openStatus = null;
@@ -67,7 +67,7 @@ public class GetDetailedOpenStatusOfAnnouncementByIdResponse {
    * Get openStatus
    * @return openStatus
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class GetDetailedOpenStatusOfAnnouncementByIdResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner.java
+++ b/src/main/java/org/openapitools/client/model/GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner.JSON_PROPERTY_OPEN_AT
 })
 @JsonTypeName("getDetailedOpenStatusOfAnnouncementByIdResponse_open_status_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -69,7 +69,7 @@ public class GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -95,7 +95,7 @@ public class GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner {
    * Get channelUrl
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -121,7 +121,7 @@ public class GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner {
    * Get hasOpened
    * @return hasOpened
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_HAS_OPENED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -147,7 +147,7 @@ public class GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner {
    * Get sentAt
    * @return sentAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENT_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -173,7 +173,7 @@ public class GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner {
    * Get openAt
    * @return openAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GetStatisticsDailyResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetStatisticsDailyResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GetStatisticsDailyResponse.JSON_PROPERTY_WEEK
 })
 @JsonTypeName("getStatisticsDailyResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GetStatisticsDailyResponse {
   public static final String JSON_PROPERTY_STATISTICS = "statistics";
   private List<GetStatisticsDailyResponseStatisticsInner> statistics = null;
@@ -68,7 +68,7 @@ public class GetStatisticsDailyResponse {
    * Get statistics
    * @return statistics
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATISTICS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class GetStatisticsDailyResponse {
    * Get week
    * @return week
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_WEEK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GetStatisticsDailyResponseStatisticsInner.java
+++ b/src/main/java/org/openapitools/client/model/GetStatisticsDailyResponseStatisticsInner.java
@@ -46,7 +46,7 @@ import org.sendbird.client.JSON;
   GetStatisticsDailyResponseStatisticsInner.JSON_PROPERTY_OPEN_COUNT
 })
 @JsonTypeName("getStatisticsDailyResponse_statistics_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GetStatisticsDailyResponseStatisticsInner {
   public static final String JSON_PROPERTY_DATE_RANGE = "date_range";
   private String dateRange;
@@ -93,7 +93,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get dateRange
    * @return dateRange
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATE_RANGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -119,7 +119,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get canceledAnnouncementCount
    * @return canceledAnnouncementCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CANCELED_ANNOUNCEMENT_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -145,7 +145,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get stoppedAnnouncementCount
    * @return stoppedAnnouncementCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STOPPED_ANNOUNCEMENT_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -171,7 +171,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get completedAnnouncementCount
    * @return completedAnnouncementCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COMPLETED_ANNOUNCEMENT_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -197,7 +197,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get totalAnnouncementCount
    * @return totalAnnouncementCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOTAL_ANNOUNCEMENT_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -223,7 +223,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get targetChannelCount
    * @return targetChannelCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_CHANNEL_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -249,7 +249,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get targetUserCount
    * @return targetUserCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_USER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -275,7 +275,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get sentChannelCount
    * @return sentChannelCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENT_CHANNEL_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -301,7 +301,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get sentUserCount
    * @return sentUserCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENT_USER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -327,7 +327,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get openRate
    * @return openRate
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_RATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -353,7 +353,7 @@ public class GetStatisticsDailyResponseStatisticsInner {
    * Get openCount
    * @return openCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GetStatisticsMonthlyResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetStatisticsMonthlyResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GetStatisticsMonthlyResponse.JSON_PROPERTY_WEEK
 })
 @JsonTypeName("getStatisticsMonthlyResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GetStatisticsMonthlyResponse {
   public static final String JSON_PROPERTY_STATISTICS = "statistics";
   private List<GetStatisticsDailyResponseStatisticsInner> statistics = null;
@@ -68,7 +68,7 @@ public class GetStatisticsMonthlyResponse {
    * Get statistics
    * @return statistics
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATISTICS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class GetStatisticsMonthlyResponse {
    * Get week
    * @return week
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_WEEK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/GetStatisticsResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetStatisticsResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GetStatisticsResponse.JSON_PROPERTY_WEEK
 })
 @JsonTypeName("getStatisticsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GetStatisticsResponse {
   public static final String JSON_PROPERTY_STATISTICS = "statistics";
   private List<GetStatisticsDailyResponseStatisticsInner> statistics = null;
@@ -68,7 +68,7 @@ public class GetStatisticsResponse {
    * Get statistics
    * @return statistics
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATISTICS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class GetStatisticsResponse {
    * Get week
    * @return week
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_WEEK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/JoinChannelsData.java
+++ b/src/main/java/org/openapitools/client/model/JoinChannelsData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   JoinChannelsData.JSON_PROPERTY_CHANNEL_URLS
 })
 @JsonTypeName("joinChannelsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class JoinChannelsData {
   public static final String JSON_PROPERTY_BOT_USERID = "bot_userid";
   private String botUserid;
@@ -58,7 +58,7 @@ public class JoinChannelsData {
    * Specifies the ID of the bot to join the channels.
    * @return botUserid
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the bot to join the channels.")
   @JsonProperty(JSON_PROPERTY_BOT_USERID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -89,7 +89,7 @@ public class JoinChannelsData {
    * Specifies an array of one or more URLs of the channels to join.
    * @return channelUrls
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more URLs of the channels to join.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URLS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/JoinChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/JoinChannelsResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   JoinChannelsResponse.JSON_PROPERTY_CHANNELS
 })
 @JsonTypeName("joinChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class JoinChannelsResponse {
   public static final String JSON_PROPERTY_CHANNELS = "channels";
   private List<SendBirdGroupChannel> channels = null;
@@ -63,7 +63,7 @@ public class JoinChannelsResponse {
    * Get channels
    * @return channels
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNELS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/LeaveMyGroupChannelsData.java
+++ b/src/main/java/org/openapitools/client/model/LeaveMyGroupChannelsData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   LeaveMyGroupChannelsData.JSON_PROPERTY_CUSTOM_TYPE
 })
 @JsonTypeName("leaveMyGroupChannelsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class LeaveMyGroupChannelsData {
   public static final String JSON_PROPERTY_CUSTOM_TYPE = "custom_type";
   private String customType;
@@ -52,7 +52,7 @@ public class LeaveMyGroupChannelsData {
    * Specifies the custom channel type to make the user leave joined group channels with the corresponding type.
    * @return customType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the custom channel type to make the user leave joined group channels with the corresponding type.")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListAllEmojisAndEmojiCategoriesResponse.JSON_PROPERTY_EMOJI_CATEGORIES
 })
 @JsonTypeName("listAllEmojisAndEmojiCategoriesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListAllEmojisAndEmojiCategoriesResponse {
   public static final String JSON_PROPERTY_EMOJI_HASH = "emoji_hash";
   private String emojiHash;
@@ -59,7 +59,7 @@ public class ListAllEmojisAndEmojiCategoriesResponse {
    * Get emojiHash
    * @return emojiHash
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EMOJI_HASH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListAllEmojisAndEmojiCategoriesResponse {
    * Get emojiCategories
    * @return emojiCategories
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EMOJI_CATEGORIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner.java
+++ b/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner.JSON_PROPERTY_EMOJIS
 })
 @JsonTypeName("listAllEmojisAndEmojiCategoriesResponse_emoji_categories_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner {
   public static final String JSON_PROPERTY_ID = "id";
   private BigDecimal id;
@@ -68,7 +68,7 @@ public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner {
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -120,7 +120,7 @@ public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -154,7 +154,7 @@ public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner {
    * Get emojis
    * @return emojis
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EMOJIS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisInner.java
+++ b/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisInner.JSON_PROPERTY_URL
 })
 @JsonTypeName("listAllEmojisAndEmojiCategoriesResponse_emoji_categories_inner_emojis_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisInner {
   public static final String JSON_PROPERTY_ID = "id";
   private BigDecimal id;
@@ -61,7 +61,7 @@ public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisIn
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -87,7 +87,7 @@ public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisIn
    * Get key
    * @return key
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -113,7 +113,7 @@ public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisIn
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListAnnouncementGroupsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListAnnouncementGroupsResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListAnnouncementGroupsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listAnnouncementGroupsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListAnnouncementGroupsResponse {
   public static final String JSON_PROPERTY_ANNOUNCEMENT_GROUPS = "announcement_groups";
   private List<String> announcementGroups = null;
@@ -66,7 +66,7 @@ public class ListAnnouncementGroupsResponse {
    * Get announcementGroups
    * @return announcementGroups
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ANNOUNCEMENT_GROUPS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class ListAnnouncementGroupsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListAnnouncementsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListAnnouncementsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListAnnouncementsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listAnnouncementsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListAnnouncementsResponse {
   public static final String JSON_PROPERTY_ANNOUNCEMENTS = "announcements";
   private List<ListAnnouncementsResponseAnnouncementsInner> announcements = null;
@@ -67,7 +67,7 @@ public class ListAnnouncementsResponse {
    * Get announcements
    * @return announcements
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ANNOUNCEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListAnnouncementsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListAnnouncementsResponseAnnouncementsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListAnnouncementsResponseAnnouncementsInner.java
@@ -59,7 +59,7 @@ import org.sendbird.client.JSON;
   ListAnnouncementsResponseAnnouncementsInner.JSON_PROPERTY_TARGET_CUSTOM_TYPE
 })
 @JsonTypeName("listAnnouncementsResponse_announcements_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListAnnouncementsResponseAnnouncementsInner {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;
@@ -139,7 +139,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get uniqueId
    * @return uniqueId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNIQUE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -165,7 +165,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get announcementGroup
    * @return announcementGroup
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ANNOUNCEMENT_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -191,7 +191,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -217,7 +217,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get enablePush
    * @return enablePush
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_PUSH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -243,7 +243,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get targetAt
    * @return targetAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -269,7 +269,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get targetUserCount
    * @return targetUserCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_USER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -295,7 +295,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get targetChannelCount
    * @return targetChannelCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_CHANNEL_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -321,7 +321,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -347,7 +347,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get scheduledAt
    * @return scheduledAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SCHEDULED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -373,7 +373,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get ceaseAt
    * @return ceaseAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CEASE_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -399,7 +399,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get resumeAt
    * @return resumeAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_RESUME_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -425,7 +425,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get completedAt
    * @return completedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COMPLETED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -451,7 +451,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get sentUserCount
    * @return sentUserCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENT_USER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -477,7 +477,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get openCount
    * @return openCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -503,7 +503,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get openRate
    * @return openRate
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_RATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -529,7 +529,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get createChannel
    * @return createChannel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -555,7 +555,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get createChannelOptions
    * @return createChannelOptions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -581,7 +581,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -607,7 +607,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get markAsRead
    * @return markAsRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MARK_AS_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -633,7 +633,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get sentChannelCount
    * @return sentChannelCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENT_CHANNEL_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -659,7 +659,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get targetChannelType
    * @return targetChannelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -685,7 +685,7 @@ public class ListAnnouncementsResponseAnnouncementsInner {
    * Get targetCustomType
    * @return targetCustomType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListBannedChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListBannedChannelsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListBannedChannelsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listBannedChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListBannedChannelsResponse {
   public static final String JSON_PROPERTY_BANNED_CHANNELS = "banned_channels";
   private List<ListBannedChannelsResponseBannedChannelsInner> bannedChannels = null;
@@ -67,7 +67,7 @@ public class ListBannedChannelsResponse {
    * Get bannedChannels
    * @return bannedChannels
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BANNED_CHANNELS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListBannedChannelsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListBannedChannelsResponseBannedChannelsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListBannedChannelsResponseBannedChannelsInner.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   ListBannedChannelsResponseBannedChannelsInner.JSON_PROPERTY_END_AT
 })
 @JsonTypeName("listBannedChannelsResponse_banned_channels_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListBannedChannelsResponseBannedChannelsInner {
   public static final String JSON_PROPERTY_START_AT = "start_at";
   private BigDecimal startAt;
@@ -66,7 +66,7 @@ public class ListBannedChannelsResponseBannedChannelsInner {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class ListBannedChannelsResponseBannedChannelsInner {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -118,7 +118,7 @@ public class ListBannedChannelsResponseBannedChannelsInner {
    * Get channel
    * @return channel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -144,7 +144,7 @@ public class ListBannedChannelsResponseBannedChannelsInner {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListBlockedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListBlockedUsersResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListBlockedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listBlockedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListBlockedUsersResponse {
   public static final String JSON_PROPERTY_USERS = "users";
   private List<SendBirdUser> users = null;
@@ -67,7 +67,7 @@ public class ListBlockedUsersResponse {
    * Get users
    * @return users
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListBlockedUsersResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListBotsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListBotsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListBotsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listBotsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListBotsResponse {
   public static final String JSON_PROPERTY_BOTS = "bots";
   private List<ListBotsResponseBotsInner> bots = null;
@@ -67,7 +67,7 @@ public class ListBotsResponse {
    * Get bots
    * @return bots
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListBotsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListBotsResponseBotsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListBotsResponseBotsInner.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   ListBotsResponseBotsInner.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("listBotsResponse_bots_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListBotsResponseBotsInner {
   public static final String JSON_PROPERTY_BOT = "bot";
   private CreateBotResponseBot bot;
@@ -74,7 +74,7 @@ public class ListBotsResponseBotsInner {
    * Get bot
    * @return bot
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -100,7 +100,7 @@ public class ListBotsResponseBotsInner {
    * Get botCallbackUrl
    * @return botCallbackUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT_CALLBACK_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -126,7 +126,7 @@ public class ListBotsResponseBotsInner {
    * Get enableMarkAsRead
    * @return enableMarkAsRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_MARK_AS_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -152,7 +152,7 @@ public class ListBotsResponseBotsInner {
    * Get isPrivacyMode
    * @return isPrivacyMode
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_PRIVACY_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -178,7 +178,7 @@ public class ListBotsResponseBotsInner {
    * Get showMember
    * @return showMember
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SHOW_MEMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -204,7 +204,7 @@ public class ListBotsResponseBotsInner {
    * Get channelInvitationPreference
    * @return channelInvitationPreference
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListDataExportsByMessageChannelOrUserResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listDataExportsByMessageChannelOrUserResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListDataExportsByMessageChannelOrUserResponse {
   public static final String JSON_PROPERTY_EXPORTED_DATA = "exported_data";
   private List<ListDataExportsByMessageChannelOrUserResponseExportedDataInner> exportedData = null;
@@ -67,7 +67,7 @@ public class ListDataExportsByMessageChannelOrUserResponse {
    * Get exportedData
    * @return exportedData
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EXPORTED_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListDataExportsByMessageChannelOrUserResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponseExportedDataInner.java
+++ b/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponseExportedDataInner.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ListDataExportsByMessageChannelOrUserResponseExportedDataInner.JSON_PROPERTY_USER_IDS
 })
 @JsonTypeName("listDataExportsByMessageChannelOrUserResponse_exported_data_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
   public static final String JSON_PROPERTY_REQUEST_ID = "request_id";
   private String requestId;
@@ -100,7 +100,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get requestId
    * @return requestId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUEST_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -126,7 +126,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -152,7 +152,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get format
    * @return format
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FORMAT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -178,7 +178,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get csvDelimiter
    * @return csvDelimiter
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CSV_DELIMITER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -204,7 +204,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get timezone
    * @return timezone
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TIMEZONE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -230,7 +230,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -256,7 +256,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get startTs
    * @return startTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -282,7 +282,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get endTs
    * @return endTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -316,7 +316,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get channelUrls
    * @return channelUrls
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -350,7 +350,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get senderIds
    * @return senderIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENDER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -376,7 +376,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get _file
    * @return _file
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -410,7 +410,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
    * Get userIds
    * @return userIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponseExportedDataInnerFile.java
+++ b/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponseExportedDataInnerFile.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ListDataExportsByMessageChannelOrUserResponseExportedDataInnerFile.JSON_PROPERTY_EXPIRES_AT
 })
 @JsonTypeName("listDataExportsByMessageChannelOrUserResponse_exported_data_inner_file")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListDataExportsByMessageChannelOrUserResponseExportedDataInnerFile {
   public static final String JSON_PROPERTY_URL = "url";
   private String url;
@@ -57,7 +57,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInnerFile 
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class ListDataExportsByMessageChannelOrUserResponseExportedDataInnerFile 
    * Get expiresAt
    * @return expiresAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EXPIRES_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListEmojisResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListEmojisResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListEmojisResponse.JSON_PROPERTY_EMOJIS
 })
 @JsonTypeName("listEmojisResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListEmojisResponse {
   public static final String JSON_PROPERTY_EMOJIS = "emojis";
   private List<SendBirdEmoji> emojis = null;
@@ -63,7 +63,7 @@ public class ListEmojisResponse {
    * Get emojis
    * @return emojis
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EMOJIS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListGdprRequestsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListGdprRequestsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListGdprRequestsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listGdprRequestsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListGdprRequestsResponse {
   public static final String JSON_PROPERTY_REQUESTS = "requests";
   private List<ListGdprRequestsResponseRequestsInner> requests = null;
@@ -67,7 +67,7 @@ public class ListGdprRequestsResponse {
    * Get requests
    * @return requests
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUESTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListGdprRequestsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListGdprRequestsResponseRequestsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListGdprRequestsResponseRequestsInner.java
@@ -46,7 +46,7 @@ import org.sendbird.client.JSON;
   ListGdprRequestsResponseRequestsInner.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("listGdprRequestsResponse_requests_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListGdprRequestsResponseRequestsInner {
   public static final String JSON_PROPERTY_REQUEST_ID = "request_id";
   private String requestId;
@@ -84,7 +84,7 @@ public class ListGdprRequestsResponseRequestsInner {
    * Get requestId
    * @return requestId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUEST_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -110,7 +110,7 @@ public class ListGdprRequestsResponseRequestsInner {
    * Get action
    * @return action
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ACTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -136,7 +136,7 @@ public class ListGdprRequestsResponseRequestsInner {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -162,7 +162,7 @@ public class ListGdprRequestsResponseRequestsInner {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -188,7 +188,7 @@ public class ListGdprRequestsResponseRequestsInner {
    * Get files
    * @return files
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -222,7 +222,7 @@ public class ListGdprRequestsResponseRequestsInner {
    * Get userIds
    * @return userIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -248,7 +248,7 @@ public class ListGdprRequestsResponseRequestsInner {
    * Get channelDeleteOption
    * @return channelDeleteOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_DELETE_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -274,7 +274,7 @@ public class ListGdprRequestsResponseRequestsInner {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListMessagesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListMessagesResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListMessagesResponse.JSON_PROPERTY_MESSAGES
 })
 @JsonTypeName("listMessagesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListMessagesResponse {
   public static final String JSON_PROPERTY_MESSAGES = "messages";
   private List<ListMessagesResponseMessagesInner> messages = null;
@@ -63,7 +63,7 @@ public class ListMessagesResponse {
    * Get messages
    * @return messages
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInner.java
+++ b/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInner.java
@@ -63,7 +63,7 @@ import org.sendbird.client.JSON;
   ListMessagesResponseMessagesInner.JSON_PROPERTY_OG_TAG
 })
 @JsonTypeName("listMessagesResponse_messages_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListMessagesResponseMessagesInner {
   public static final String JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS = "message_survival_seconds";
   private BigDecimal messageSurvivalSeconds;
@@ -143,7 +143,7 @@ public class ListMessagesResponseMessagesInner {
    * Get messageSurvivalSeconds
    * @return messageSurvivalSeconds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -169,7 +169,7 @@ public class ListMessagesResponseMessagesInner {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -203,7 +203,7 @@ public class ListMessagesResponseMessagesInner {
    * Get mentionedUsers
    * @return mentionedUsers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -229,7 +229,7 @@ public class ListMessagesResponseMessagesInner {
    * Get translations
    * @return translations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TRANSLATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -255,7 +255,7 @@ public class ListMessagesResponseMessagesInner {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -281,7 +281,7 @@ public class ListMessagesResponseMessagesInner {
    * Get isOpMsg
    * @return isOpMsg
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_OP_MSG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -307,7 +307,7 @@ public class ListMessagesResponseMessagesInner {
    * Get isRemoved
    * @return isRemoved
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_REMOVED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -333,7 +333,7 @@ public class ListMessagesResponseMessagesInner {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -359,7 +359,7 @@ public class ListMessagesResponseMessagesInner {
    * Get _file
    * @return _file
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -385,7 +385,7 @@ public class ListMessagesResponseMessagesInner {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -411,7 +411,7 @@ public class ListMessagesResponseMessagesInner {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -437,7 +437,7 @@ public class ListMessagesResponseMessagesInner {
    * Get messageRetentionHour
    * @return messageRetentionHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_RETENTION_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -463,7 +463,7 @@ public class ListMessagesResponseMessagesInner {
    * Get silent
    * @return silent
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SILENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -489,7 +489,7 @@ public class ListMessagesResponseMessagesInner {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -515,7 +515,7 @@ public class ListMessagesResponseMessagesInner {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -541,7 +541,7 @@ public class ListMessagesResponseMessagesInner {
    * Get channelType
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -567,7 +567,7 @@ public class ListMessagesResponseMessagesInner {
    * Get reqId
    * @return reqId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQ_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -593,7 +593,7 @@ public class ListMessagesResponseMessagesInner {
    * Get mentionType
    * @return mentionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -619,7 +619,7 @@ public class ListMessagesResponseMessagesInner {
    * Get channelUrl
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -645,7 +645,7 @@ public class ListMessagesResponseMessagesInner {
    * Get messageId
    * @return messageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -679,7 +679,7 @@ public class ListMessagesResponseMessagesInner {
    * Get sortedMetaarray
    * @return sortedMetaarray
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SORTED_METAARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -705,7 +705,7 @@ public class ListMessagesResponseMessagesInner {
    * Get ogTag
    * @return ogTag
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OG_TAG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerOgTag.java
+++ b/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerOgTag.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListMessagesResponseMessagesInnerOgTag.JSON_PROPERTY_OG_COLON_IMAGE
 })
 @JsonTypeName("listMessagesResponse_messages_inner_og_tag")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListMessagesResponseMessagesInnerOgTag {
   public static final String JSON_PROPERTY_OG_COLON_URL = "og:url";
   private String ogColonUrl;
@@ -65,7 +65,7 @@ public class ListMessagesResponseMessagesInnerOgTag {
    * Get ogColonUrl
    * @return ogColonUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OG_COLON_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -91,7 +91,7 @@ public class ListMessagesResponseMessagesInnerOgTag {
    * Get ogColonTitle
    * @return ogColonTitle
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OG_COLON_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -117,7 +117,7 @@ public class ListMessagesResponseMessagesInnerOgTag {
    * Get ogColonDescription
    * @return ogColonDescription
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OG_COLON_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -143,7 +143,7 @@ public class ListMessagesResponseMessagesInnerOgTag {
    * Get ogColonImage
    * @return ogColonImage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OG_COLON_IMAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerOgTagOgImage.java
+++ b/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerOgTagOgImage.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListMessagesResponseMessagesInnerOgTagOgImage.JSON_PROPERTY_HEIGHT
 })
 @JsonTypeName("listMessagesResponse_messages_inner_og_tag_og_image")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListMessagesResponseMessagesInnerOgTagOgImage {
   public static final String JSON_PROPERTY_URL = "url";
   private String url;
@@ -65,7 +65,7 @@ public class ListMessagesResponseMessagesInnerOgTagOgImage {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -91,7 +91,7 @@ public class ListMessagesResponseMessagesInnerOgTagOgImage {
    * Get secureUrl
    * @return secureUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SECURE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -117,7 +117,7 @@ public class ListMessagesResponseMessagesInnerOgTagOgImage {
    * Get width
    * @return width
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_WIDTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -143,7 +143,7 @@ public class ListMessagesResponseMessagesInnerOgTagOgImage {
    * Get height
    * @return height
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_HEIGHT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerSortedMetaarrayInner.java
+++ b/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerSortedMetaarrayInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListMessagesResponseMessagesInnerSortedMetaarrayInner.JSON_PROPERTY_VALUE
 })
 @JsonTypeName("listMessagesResponse_messages_inner_sorted_metaarray_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListMessagesResponseMessagesInnerSortedMetaarrayInner {
   public static final String JSON_PROPERTY_KEY = "key";
   private String key;
@@ -58,7 +58,7 @@ public class ListMessagesResponseMessagesInnerSortedMetaarrayInner {
    * Get key
    * @return key
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class ListMessagesResponseMessagesInnerSortedMetaarrayInner {
    * Get value
    * @return value
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VALUE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListMutedChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListMutedChannelsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListMutedChannelsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listMutedChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListMutedChannelsResponse {
   public static final String JSON_PROPERTY_MUTED_CHANNELS = "muted_channels";
   private List<SendBirdChannelResponse> mutedChannels = null;
@@ -67,7 +67,7 @@ public class ListMutedChannelsResponse {
    * Get mutedChannels
    * @return mutedChannels
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MUTED_CHANNELS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListMutedChannelsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListMutedUsersInChannelsWithCustomChannelType200Response.java
+++ b/src/main/java/org/openapitools/client/model/ListMutedUsersInChannelsWithCustomChannelType200Response.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListMutedUsersInChannelsWithCustomChannelType200Response.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listMutedUsersInChannelsWithCustomChannelType_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListMutedUsersInChannelsWithCustomChannelType200Response {
   public static final String JSON_PROPERTY_MUTED_LIST = "muted_list";
   private List<SendBirdUser> mutedList = null;
@@ -67,7 +67,7 @@ public class ListMutedUsersInChannelsWithCustomChannelType200Response {
    * Get mutedList
    * @return mutedList
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MUTED_LIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListMutedUsersInChannelsWithCustomChannelType200Response {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListMyGroupChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListMyGroupChannelsResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   ListMyGroupChannelsResponse.JSON_PROPERTY_TS
 })
 @JsonTypeName("listMyGroupChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListMyGroupChannelsResponse {
   public static final String JSON_PROPERTY_CHANNELS = "channels";
   private List<SendBirdGroupChannel> channels = null;
@@ -72,7 +72,7 @@ public class ListMyGroupChannelsResponse {
    * Get channels
    * @return channels
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNELS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -98,7 +98,7 @@ public class ListMyGroupChannelsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class ListMyGroupChannelsResponse {
    * Get ts
    * @return ts
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListPushConfigurationsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListPushConfigurationsResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListPushConfigurationsResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("listPushConfigurationsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListPushConfigurationsResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<ListPushConfigurationsResponsePushConfigurationsInner> pushConfigurations = null;
@@ -63,7 +63,7 @@ public class ListPushConfigurationsResponse {
    * Get pushConfigurations
    * @return pushConfigurations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_CONFIGURATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListPushConfigurationsResponsePushConfigurationsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListPushConfigurationsResponsePushConfigurationsInner.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   ListPushConfigurationsResponsePushConfigurationsInner.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("listPushConfigurationsResponse_push_configurations_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListPushConfigurationsResponsePushConfigurationsInner {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;
@@ -73,7 +73,7 @@ public class ListPushConfigurationsResponsePushConfigurationsInner {
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -99,7 +99,7 @@ public class ListPushConfigurationsResponsePushConfigurationsInner {
    * Get pushType
    * @return pushType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -125,7 +125,7 @@ public class ListPushConfigurationsResponsePushConfigurationsInner {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -151,7 +151,7 @@ public class ListPushConfigurationsResponsePushConfigurationsInner {
    * Get apiKey
    * @return apiKey
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_API_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -177,7 +177,7 @@ public class ListPushConfigurationsResponsePushConfigurationsInner {
    * Get senderId
    * @return senderId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENDER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -203,7 +203,7 @@ public class ListPushConfigurationsResponsePushConfigurationsInner {
    * Get pushSound
    * @return pushSound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListPushNotificationContentTemplatesResponse.JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES
 })
 @JsonTypeName("listPushNotificationContentTemplatesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListPushNotificationContentTemplatesResponse {
   public static final String JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES = "push_message_templates";
   private List<ListPushNotificationContentTemplatesResponsePushMessageTemplatesInner> pushMessageTemplates = null;
@@ -63,7 +63,7 @@ public class ListPushNotificationContentTemplatesResponse {
    * Get pushMessageTemplates
    * @return pushMessageTemplates
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponsePushMessageTemplatesInner.java
+++ b/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponsePushMessageTemplatesInner.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ListPushNotificationContentTemplatesResponsePushMessageTemplatesInner.JSON_PROPERTY_TEMPLATE
 })
 @JsonTypeName("listPushNotificationContentTemplatesResponse_push_message_templates_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListPushNotificationContentTemplatesResponsePushMessageTemplatesInner {
   public static final String JSON_PROPERTY_TEMPLATE_NAME = "template_name";
   private String templateName;
@@ -57,7 +57,7 @@ public class ListPushNotificationContentTemplatesResponsePushMessageTemplatesInn
    * Get templateName
    * @return templateName
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TEMPLATE_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class ListPushNotificationContentTemplatesResponsePushMessageTemplatesInn
    * Get template
    * @return template
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TEMPLATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponsePushMessageTemplatesInnerTemplate.java
+++ b/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponsePushMessageTemplatesInnerTemplate.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ListPushNotificationContentTemplatesResponsePushMessageTemplatesInnerTemplate.JSON_PROPERTY_A_D_M_M
 })
 @JsonTypeName("listPushNotificationContentTemplatesResponse_push_message_templates_inner_template")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListPushNotificationContentTemplatesResponsePushMessageTemplatesInnerTemplate {
   public static final String JSON_PROPERTY_M_E_S_G = "MESG";
   private String MESG;
@@ -60,7 +60,7 @@ public class ListPushNotificationContentTemplatesResponsePushMessageTemplatesInn
    * Get MESG
    * @return MESG
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_M_E_S_G)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -86,7 +86,7 @@ public class ListPushNotificationContentTemplatesResponsePushMessageTemplatesInn
    * Get FILE
    * @return FILE
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_F_I_L_E)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -112,7 +112,7 @@ public class ListPushNotificationContentTemplatesResponsePushMessageTemplatesInn
    * Get ADMM
    * @return ADMM
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_A_D_M_M)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListReactionsOfMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListReactionsOfMessageResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ListReactionsOfMessageResponse.JSON_PROPERTY_KEY
 })
 @JsonTypeName("listReactionsOfMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListReactionsOfMessageResponse {
   public static final String JSON_PROPERTY_KEY = "key";
   private List<String> key = null;
@@ -62,7 +62,7 @@ public class ListReactionsOfMessageResponse {
    * Get key
    * @return key
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListRegistrationOrDeviceTokensResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListRegistrationOrDeviceTokensResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   ListRegistrationOrDeviceTokensResponse.JSON_PROPERTY_USER
 })
 @JsonTypeName("listRegistrationOrDeviceTokensResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListRegistrationOrDeviceTokensResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private List<String> token = null;
@@ -75,7 +75,7 @@ public class ListRegistrationOrDeviceTokensResponse {
    * Get token
    * @return token
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -109,7 +109,7 @@ public class ListRegistrationOrDeviceTokensResponse {
    * Get tokens
    * @return tokens
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOKENS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -135,7 +135,7 @@ public class ListRegistrationOrDeviceTokensResponse {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -161,7 +161,7 @@ public class ListRegistrationOrDeviceTokensResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListReportsOnChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsOnChannelByUrlResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListReportsOnChannelByUrlResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listReportsOnChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListReportsOnChannelByUrlResponse {
   public static final String JSON_PROPERTY_REPORT_LOGS = "report_logs";
   private List<ListReportsOnMessageByIdResponseReportLogsInner> reportLogs = null;
@@ -67,7 +67,7 @@ public class ListReportsOnChannelByUrlResponse {
    * Get reportLogs
    * @return reportLogs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_LOGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListReportsOnChannelByUrlResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListReportsOnMessageByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsOnMessageByIdResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListReportsOnMessageByIdResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listReportsOnMessageByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListReportsOnMessageByIdResponse {
   public static final String JSON_PROPERTY_REPORT_LOGS = "report_logs";
   private List<ListReportsOnMessageByIdResponseReportLogsInner> reportLogs = null;
@@ -67,7 +67,7 @@ public class ListReportsOnMessageByIdResponse {
    * Get reportLogs
    * @return reportLogs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_LOGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListReportsOnMessageByIdResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListReportsOnMessageByIdResponseReportLogsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsOnMessageByIdResponseReportLogsInner.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ListReportsOnMessageByIdResponseReportLogsInner.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("listReportsOnMessageByIdResponse_report_logs_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListReportsOnMessageByIdResponseReportLogsInner {
   public static final String JSON_PROPERTY_REPORT_TYPE = "report_type";
   private String reportType;
@@ -88,7 +88,7 @@ public class ListReportsOnMessageByIdResponseReportLogsInner {
    * Get reportType
    * @return reportType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -114,7 +114,7 @@ public class ListReportsOnMessageByIdResponseReportLogsInner {
    * Get reportCategory
    * @return reportCategory
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -140,7 +140,7 @@ public class ListReportsOnMessageByIdResponseReportLogsInner {
    * Get reportingUser
    * @return reportingUser
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORTING_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -166,7 +166,7 @@ public class ListReportsOnMessageByIdResponseReportLogsInner {
    * Get offendingUser
    * @return offendingUser
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OFFENDING_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -192,7 +192,7 @@ public class ListReportsOnMessageByIdResponseReportLogsInner {
    * Get reportedMessage
    * @return reportedMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -226,7 +226,7 @@ public class ListReportsOnMessageByIdResponseReportLogsInner {
    * Get channel
    * @return channel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -252,7 +252,7 @@ public class ListReportsOnMessageByIdResponseReportLogsInner {
    * Get reportDescription
    * @return reportDescription
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -278,7 +278,7 @@ public class ListReportsOnMessageByIdResponseReportLogsInner {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListReportsOnUserByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsOnUserByIdResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListReportsOnUserByIdResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listReportsOnUserByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListReportsOnUserByIdResponse {
   public static final String JSON_PROPERTY_REPORT_LOGS = "report_logs";
   private List<ListReportsOnMessageByIdResponseReportLogsInner> reportLogs = null;
@@ -67,7 +67,7 @@ public class ListReportsOnUserByIdResponse {
    * Get reportLogs
    * @return reportLogs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_LOGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListReportsOnUserByIdResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListReportsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListReportsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listReportsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListReportsResponse {
   public static final String JSON_PROPERTY_REPORT_LOGS = "report_logs";
   private List<ListReportsResponseReportLogsInner> reportLogs = null;
@@ -67,7 +67,7 @@ public class ListReportsResponse {
    * Get reportLogs
    * @return reportLogs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_LOGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListReportsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListReportsResponseReportLogsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsResponseReportLogsInner.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ListReportsResponseReportLogsInner.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("listReportsResponse_report_logs_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListReportsResponseReportLogsInner {
   public static final String JSON_PROPERTY_REPORTING_USER = "reporting_user";
   private SendBirdUser reportingUser;
@@ -88,7 +88,7 @@ public class ListReportsResponseReportLogsInner {
    * Get reportingUser
    * @return reportingUser
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORTING_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -114,7 +114,7 @@ public class ListReportsResponseReportLogsInner {
    * Get reportType
    * @return reportType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -140,7 +140,7 @@ public class ListReportsResponseReportLogsInner {
    * Get reportCategory
    * @return reportCategory
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -166,7 +166,7 @@ public class ListReportsResponseReportLogsInner {
    * Get offendingUser
    * @return offendingUser
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OFFENDING_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -192,7 +192,7 @@ public class ListReportsResponseReportLogsInner {
    * Get reportedMessage
    * @return reportedMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -226,7 +226,7 @@ public class ListReportsResponseReportLogsInner {
    * Get channel
    * @return channel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -252,7 +252,7 @@ public class ListReportsResponseReportLogsInner {
    * Get reportDescription
    * @return reportDescription
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -278,7 +278,7 @@ public class ListReportsResponseReportLogsInner {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListSecondaryApiTokensResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListSecondaryApiTokensResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListSecondaryApiTokensResponse.JSON_PROPERTY_API_TOKENS
 })
 @JsonTypeName("listSecondaryApiTokensResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListSecondaryApiTokensResponse {
   public static final String JSON_PROPERTY_API_TOKENS = "api_tokens";
   private List<ListSecondaryApiTokensResponseApiTokensInner> apiTokens = null;
@@ -63,7 +63,7 @@ public class ListSecondaryApiTokensResponse {
    * Get apiTokens
    * @return apiTokens
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_API_TOKENS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListSecondaryApiTokensResponseApiTokensInner.java
+++ b/src/main/java/org/openapitools/client/model/ListSecondaryApiTokensResponseApiTokensInner.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ListSecondaryApiTokensResponseApiTokensInner.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("listSecondaryApiTokensResponse_api_tokens_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListSecondaryApiTokensResponseApiTokensInner {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;
@@ -57,7 +57,7 @@ public class ListSecondaryApiTokensResponseApiTokensInner {
    * Get token
    * @return token
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class ListSecondaryApiTokensResponseApiTokensInner {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ListUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListUsersResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ListUsersResponse {
   public static final String JSON_PROPERTY_USERS = "users";
   private List<SendBirdUser> users = null;
@@ -67,7 +67,7 @@ public class ListUsersResponse {
    * Get users
    * @return users
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class ListUsersResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/MarkAllMessagesAsReadData.java
+++ b/src/main/java/org/openapitools/client/model/MarkAllMessagesAsReadData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   MarkAllMessagesAsReadData.JSON_PROPERTY_CHANNEL_URLS
 })
 @JsonTypeName("markAllMessagesAsReadData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class MarkAllMessagesAsReadData {
   public static final String JSON_PROPERTY_CHANNEL_URLS = "channel_urls";
   private List<String> channelUrls = new ArrayList<>();
@@ -59,7 +59,7 @@ public class MarkAllMessagesAsReadData {
    * Specifies an array of one or more group channel URLs to mark all of the unread messages in as read. If not specified, all of the unread messages in the joined group channels are marked as read.
    * @return channelUrls
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more group channel URLs to mark all of the unread messages in as read. If not specified, all of the unread messages in the joined group channels are marked as read.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URLS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/ModelFile.java
+++ b/src/main/java/org/openapitools/client/model/ModelFile.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   ModelFile.JSON_PROPERTY_WEBKIT_RELATIVE_PATH
 })
 @JsonTypeName("File")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ModelFile {
   public static final String JSON_PROPERTY_LAST_MODIFIED = "last_modified";
   private BigDecimal lastModified;
@@ -69,7 +69,7 @@ public class ModelFile {
    * Get lastModified
    * @return lastModified
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_LAST_MODIFIED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -95,7 +95,7 @@ public class ModelFile {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -121,7 +121,7 @@ public class ModelFile {
    * Get size
    * @return size
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SIZE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -147,7 +147,7 @@ public class ModelFile {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -173,7 +173,7 @@ public class ModelFile {
    * Get webkitRelativePath
    * @return webkitRelativePath
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_WEBKIT_RELATIVE_PATH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/MuteInChannelsWithCustomChannelTypesData.java
+++ b/src/main/java/org/openapitools/client/model/MuteInChannelsWithCustomChannelTypesData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   MuteInChannelsWithCustomChannelTypesData.JSON_PROPERTY_CHANNEL_CUSTOM_TYPES
 })
 @JsonTypeName("muteInChannelsWithCustomChannelTypesData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class MuteInChannelsWithCustomChannelTypesData {
   public static final String JSON_PROPERTY_CHANNEL_CUSTOM_TYPES = "channel_custom_types";
   private List<String> channelCustomTypes = new ArrayList<>();
@@ -59,7 +59,7 @@ public class MuteInChannelsWithCustomChannelTypesData {
    * Specifies an array of one or more custom channel types, in order to mute the user in channels with the channel types. The user is permanently muted unless unmuted (10 years, technically).
    * @return channelCustomTypes
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more custom channel types, in order to mute the user in channels with the channel types. The user is permanently muted unless unmuted (10 years, technically).")
   @JsonProperty(JSON_PROPERTY_CHANNEL_CUSTOM_TYPES)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/MuteUsersInChannelsWithCustomChannelTypeData.java
+++ b/src/main/java/org/openapitools/client/model/MuteUsersInChannelsWithCustomChannelTypeData.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   MuteUsersInChannelsWithCustomChannelTypeData.JSON_PROPERTY_ON_DEMAND_UPSERT
 })
 @JsonTypeName("muteUsersInChannelsWithCustomChannelTypeData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class MuteUsersInChannelsWithCustomChannelTypeData {
   public static final String JSON_PROPERTY_USER_IDS = "user_ids";
   private List<String> userIds = new ArrayList<>();
@@ -72,7 +72,7 @@ public class MuteUsersInChannelsWithCustomChannelTypeData {
    * Get userIds
    * @return userIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -98,7 +98,7 @@ public class MuteUsersInChannelsWithCustomChannelTypeData {
    * Get seconds
    * @return seconds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SECONDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class MuteUsersInChannelsWithCustomChannelTypeData {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -150,7 +150,7 @@ public class MuteUsersInChannelsWithCustomChannelTypeData {
    * Get onDemandUpsert
    * @return onDemandUpsert
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ON_DEMAND_UPSERT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcBanUserData.java
+++ b/src/main/java/org/openapitools/client/model/OcBanUserData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   OcBanUserData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("ocBanUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcBanUserData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -68,7 +68,7 @@ public class OcBanUserData {
    * Specifies the URL of the channel where to ban the specified user.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel where to ban the specified user.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -94,7 +94,7 @@ public class OcBanUserData {
    * Specifies the ID of the user to ban.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the user to ban.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -120,7 +120,7 @@ public class OcBanUserData {
    * Specifies the ID of the operator (agent) who bans the user.
    * @return agentId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the operator (agent) who bans the user.")
   @JsonProperty(JSON_PROPERTY_AGENT_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -146,7 +146,7 @@ public class OcBanUserData {
    * Specifies the ban duration. If set to -1, the user will be banned permanently (10 years, technically). (Default: -1)
    * @return seconds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ban duration. If set to -1, the user will be banned permanently (10 years, technically). (Default: -1)")
   @JsonProperty(JSON_PROPERTY_SECONDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -172,7 +172,7 @@ public class OcBanUserData {
    * Specifies a reason for the banning. The length is limited to 250 characters.
    * @return description
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a reason for the banning. The length is limited to 250 characters.")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/OcBanUserResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcBanUserResponse.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   OcBanUserResponse.JSON_PROPERTY_METADATA
 })
 @JsonTypeName("ocBanUserResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcBanUserResponse {
   public static final String JSON_PROPERTY_START_AT = "start_at";
   private BigDecimal startAt;
@@ -91,7 +91,7 @@ public class OcBanUserResponse {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -117,7 +117,7 @@ public class OcBanUserResponse {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -143,7 +143,7 @@ public class OcBanUserResponse {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -169,7 +169,7 @@ public class OcBanUserResponse {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -195,7 +195,7 @@ public class OcBanUserResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -221,7 +221,7 @@ public class OcBanUserResponse {
    * Get nextUrl
    * @return nextUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -247,7 +247,7 @@ public class OcBanUserResponse {
    * Get requireAuthForProfileImage
    * @return requireAuthForProfileImage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -273,7 +273,7 @@ public class OcBanUserResponse {
    * Get nickname
    * @return nickname
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -299,7 +299,7 @@ public class OcBanUserResponse {
    * Get profileUrl
    * @return profileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -325,7 +325,7 @@ public class OcBanUserResponse {
    * Get metadata
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcCreateChannelData.java
+++ b/src/main/java/org/openapitools/client/model/OcCreateChannelData.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   OcCreateChannelData.JSON_PROPERTY_OPERATORS
 })
 @JsonTypeName("ocCreateChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcCreateChannelData {
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;
@@ -91,7 +91,7 @@ public class OcCreateChannelData {
    * Specifies the channel topic, or the name of the channel. The length is limited to 191 characters. (Default: open channel)
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the channel topic, or the name of the channel. The length is limited to 191 characters. (Default: open channel)")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -117,7 +117,7 @@ public class OcCreateChannelData {
    * Specifies the URL of the channel. Only numbers, characters, and underscores are allowed. The length is 4 to 100 characters, inclusive. If not specified, a URL is automatically generated.
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the channel. Only numbers, characters, and underscores are allowed. The length is 4 to 100 characters, inclusive. If not specified, a URL is automatically generated.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -143,7 +143,7 @@ public class OcCreateChannelData {
    * Specifies the URL of the cover image. The length is limited to 2,048 characters.
    * @return coverUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the cover image. The length is limited to 2,048 characters.")
   @JsonProperty(JSON_PROPERTY_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -169,7 +169,7 @@ public class OcCreateChannelData {
    * Uploads a file for the channel cover image.
    * @return coverFile
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Uploads a file for the channel cover image.")
   @JsonProperty(JSON_PROPERTY_COVER_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -195,7 +195,7 @@ public class OcCreateChannelData {
    * Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.&lt;br /&gt;&lt;br /&gt; Custom types are also used within Sendbird&#39;s [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.<br /><br /> Custom types are also used within Sendbird's [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -221,7 +221,7 @@ public class OcCreateChannelData {
    * Specifies additional channel information such as a long description of the channel or &#x60;JSON&#x60; formatted string.
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional channel information such as a long description of the channel or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -247,7 +247,7 @@ public class OcCreateChannelData {
    * Determines whether to preserve the messages in the channel for the purpose of retrieving chat history or not. It set to true, the messages in the channel are not saved in the Sendbird database and the chat history can&#39;t be retrieved. (Default: false)
    * @return isEphemeral
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to preserve the messages in the channel for the purpose of retrieving chat history or not. It set to true, the messages in the channel are not saved in the Sendbird database and the chat history can't be retrieved. (Default: false)")
   @JsonProperty(JSON_PROPERTY_IS_EPHEMERAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -273,7 +273,7 @@ public class OcCreateChannelData {
    * Determines whether the channel is an open channel with dynamic partitioning or not. If the value of this property is true, the open channel can create several subchannels in order to accommodate a massive number of usres. (Default: false)&lt;br/&gt;&lt;br/&gt;  For the new Sendbird applications created after December 15, 2020, this property will be automatically set to true.
    * @return isDynamicPartitionedHash2HowDynamicPartitioningWorks
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether the channel is an open channel with dynamic partitioning or not. If the value of this property is true, the open channel can create several subchannels in order to accommodate a massive number of usres. (Default: false)<br/><br/>  For the new Sendbird applications created after December 15, 2020, this property will be automatically set to true.")
   @JsonProperty(JSON_PROPERTY_IS_DYNAMIC_PARTITIONED_HASH2_HOW_DYNAMIC_PARTITIONING_WORKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -307,7 +307,7 @@ public class OcCreateChannelData {
    * Specifies an array of one or more user IDs to register as operators of the channel. The maximum allowed number of operators per channel is 100. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.&lt;br/&gt;&lt;br/&gt;  Operators cannot view messages that have been [moderated by](/docs/chat/v3/platform-api/guides/filter-and-moderation) the domain filter or profanity filter. Only the sender will be notified that the message has been blocked.
    * @return operatorIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more user IDs to register as operators of the channel. The maximum allowed number of operators per channel is 100. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.<br/><br/>  Operators cannot view messages that have been [moderated by](/docs/chat/v3/platform-api/guides/filter-and-moderation) the domain filter or profanity filter. Only the sender will be notified that the message has been blocked.")
   @JsonProperty(JSON_PROPERTY_OPERATOR_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -341,7 +341,7 @@ public class OcCreateChannelData {
    * (Deprecated) Specifies the string IDs of the users registered as channel operators. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.
    * @return operators
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "(Deprecated) Specifies the string IDs of the users registered as channel operators. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.")
   @JsonProperty(JSON_PROPERTY_OPERATORS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcDeleteChannelByUrl200Response.java
+++ b/src/main/java/org/openapitools/client/model/OcDeleteChannelByUrl200Response.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   OcDeleteChannelByUrl200Response.JSON_PROPERTY_ANY_OF
 })
 @JsonTypeName("ocDeleteChannelByUrl_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcDeleteChannelByUrl200Response {
   public static final String JSON_PROPERTY_ANY_OF = "anyOf";
   private String anyOf;
@@ -52,7 +52,7 @@ public class OcDeleteChannelByUrl200Response {
    * Get anyOf
    * @return anyOf
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ANY_OF)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcFreezeChannelData.java
+++ b/src/main/java/org/openapitools/client/model/OcFreezeChannelData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   OcFreezeChannelData.JSON_PROPERTY_FREEZE
 })
 @JsonTypeName("ocFreezeChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcFreezeChannelData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -56,7 +56,7 @@ public class OcFreezeChannelData {
    * Specifies the URL of the channel to freeze.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to freeze.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -82,7 +82,7 @@ public class OcFreezeChannelData {
    * Determines whether to freeze the channel. (Default: false)
    * @return freeze
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to freeze the channel. (Default: false)")
   @JsonProperty(JSON_PROPERTY_FREEZE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/OcListBannedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcListBannedUsersResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   OcListBannedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("ocListBannedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcListBannedUsersResponse {
   public static final String JSON_PROPERTY_BANNED_LIST = "banned_list";
   private List<OcListBannedUsersResponseBannedListInner> bannedList = null;
@@ -72,7 +72,7 @@ public class OcListBannedUsersResponse {
    * Get bannedList
    * @return bannedList
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BANNED_LIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -98,7 +98,7 @@ public class OcListBannedUsersResponse {
    * Get totalBanCount
    * @return totalBanCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOTAL_BAN_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class OcListBannedUsersResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcListBannedUsersResponseBannedListInner.java
+++ b/src/main/java/org/openapitools/client/model/OcListBannedUsersResponseBannedListInner.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   OcListBannedUsersResponseBannedListInner.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("ocListBannedUsersResponse_banned_list_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcListBannedUsersResponseBannedListInner {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;
@@ -66,7 +66,7 @@ public class OcListBannedUsersResponseBannedListInner {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class OcListBannedUsersResponseBannedListInner {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -118,7 +118,7 @@ public class OcListBannedUsersResponseBannedListInner {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -144,7 +144,7 @@ public class OcListBannedUsersResponseBannedListInner {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcListChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcListChannelsResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   OcListChannelsResponse.JSON_PROPERTY_TS
 })
 @JsonTypeName("ocListChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcListChannelsResponse {
   public static final String JSON_PROPERTY_CHANNELS = "channels";
   private List<SendBirdOpenChannel> channels = null;
@@ -72,7 +72,7 @@ public class OcListChannelsResponse {
    * Get channels
    * @return channels
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNELS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -98,7 +98,7 @@ public class OcListChannelsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class OcListChannelsResponse {
    * Get ts
    * @return ts
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcListMutedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcListMutedUsersResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   OcListMutedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("ocListMutedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcListMutedUsersResponse {
   public static final String JSON_PROPERTY_MUTED_LIST = "muted_list";
   private List<SendBirdUser> mutedList = null;
@@ -72,7 +72,7 @@ public class OcListMutedUsersResponse {
    * Get mutedList
    * @return mutedList
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MUTED_LIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -98,7 +98,7 @@ public class OcListMutedUsersResponse {
    * Get totalMuteCount
    * @return totalMuteCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOTAL_MUTE_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class OcListMutedUsersResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcListOperatorsResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcListOperatorsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   OcListOperatorsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("ocListOperatorsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcListOperatorsResponse {
   public static final String JSON_PROPERTY_OPERATORS = "operators";
   private List<SendBirdUser> operators = null;
@@ -67,7 +67,7 @@ public class OcListOperatorsResponse {
    * Get operators
    * @return operators
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPERATORS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class OcListOperatorsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcListParticipantsResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcListParticipantsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   OcListParticipantsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("ocListParticipantsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcListParticipantsResponse {
   public static final String JSON_PROPERTY_PARTICIPANTS = "participants";
   private List<SendBirdUser> participants = null;
@@ -67,7 +67,7 @@ public class OcListParticipantsResponse {
    * Get participants
    * @return participants
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARTICIPANTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class OcListParticipantsResponse {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcMuteUserData.java
+++ b/src/main/java/org/openapitools/client/model/OcMuteUserData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   OcMuteUserData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("ocMuteUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcMuteUserData {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -60,7 +60,7 @@ public class OcMuteUserData {
    * Specifies the ID of the target user to mute.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the target user to mute.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class OcMuteUserData {
    * Specifies the duration of mute status. If set to -1, the user will be muted permanently (10 years, technically). (Default: -1)
    * @return seconds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the duration of mute status. If set to -1, the user will be muted permanently (10 years, technically). (Default: -1)")
   @JsonProperty(JSON_PROPERTY_SECONDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class OcMuteUserData {
    * Specifies a reason for the muting.
    * @return description
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a reason for the muting.")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/OcRegisterOperatorsData.java
+++ b/src/main/java/org/openapitools/client/model/OcRegisterOperatorsData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   OcRegisterOperatorsData.JSON_PROPERTY_OPERATOR_IDS
 })
 @JsonTypeName("ocRegisterOperatorsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcRegisterOperatorsData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -58,7 +58,7 @@ public class OcRegisterOperatorsData {
    * Specifies the URL of the channel to register operators to.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to register operators to.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -89,7 +89,7 @@ public class OcRegisterOperatorsData {
    * Specifies an array of one or more IDs of users to register as operators of the channel. The maximum allowed number of operators per channel is 100.
    * @return operatorIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more IDs of users to register as operators of the channel. The maximum allowed number of operators per channel is 100.")
   @JsonProperty(JSON_PROPERTY_OPERATOR_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/OcUpdateBanByIdData.java
+++ b/src/main/java/org/openapitools/client/model/OcUpdateBanByIdData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   OcUpdateBanByIdData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("ocUpdateBanByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcUpdateBanByIdData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -64,7 +64,7 @@ public class OcUpdateBanByIdData {
    * Specifies the URL of the target channel.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the target channel.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -90,7 +90,7 @@ public class OcUpdateBanByIdData {
    * Specifies the ID of the banned user to update.
    * @return bannedUserId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the banned user to update.")
   @JsonProperty(JSON_PROPERTY_BANNED_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -116,7 +116,7 @@ public class OcUpdateBanByIdData {
    * Specifies a new ban duration to update. If set to -1, the user will be banned permanently (10 years, technically).
    * @return seconds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a new ban duration to update. If set to -1, the user will be banned permanently (10 years, technically).")
   @JsonProperty(JSON_PROPERTY_SECONDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -142,7 +142,7 @@ public class OcUpdateBanByIdData {
    * Specifies a new reason for the banning to update. The length is limited to 250 characters.
    * @return description
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a new reason for the banning to update. The length is limited to 250 characters.")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/OcUpdateBanByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcUpdateBanByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   OcUpdateBanByIdResponse.JSON_PROPERTY_START_AT
 })
 @JsonTypeName("ocUpdateBanByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcUpdateBanByIdResponse {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;
@@ -66,7 +66,7 @@ public class OcUpdateBanByIdResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class OcUpdateBanByIdResponse {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -118,7 +118,7 @@ public class OcUpdateBanByIdResponse {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -144,7 +144,7 @@ public class OcUpdateBanByIdResponse {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcUpdateChannelByUrlData.java
+++ b/src/main/java/org/openapitools/client/model/OcUpdateChannelByUrlData.java
@@ -45,7 +45,7 @@ import org.sendbird.client.JSON;
   OcUpdateChannelByUrlData.JSON_PROPERTY_OPERATORS
 })
 @JsonTypeName("ocUpdateChannelByUrlData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcUpdateChannelByUrlData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -83,7 +83,7 @@ public class OcUpdateChannelByUrlData {
    * Specifies the URL of the channel to update.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel to update.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -109,7 +109,7 @@ public class OcUpdateChannelByUrlData {
    * Specifies the channel topic, or the name of the channel. The length is limited to 191 characters.
    * @return name
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the channel topic, or the name of the channel. The length is limited to 191 characters.")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -135,7 +135,7 @@ public class OcUpdateChannelByUrlData {
    * Specifies the URL of the cover image. The length is limited to 2,048 characters.
    * @return coverUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the cover image. The length is limited to 2,048 characters.")
   @JsonProperty(JSON_PROPERTY_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -161,7 +161,7 @@ public class OcUpdateChannelByUrlData {
    * Uploads the file for the channel cover image.
    * @return coverFile
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Uploads the file for the channel cover image.")
   @JsonProperty(JSON_PROPERTY_COVER_FILE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -187,7 +187,7 @@ public class OcUpdateChannelByUrlData {
    * Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.&lt;br /&gt;&lt;br /&gt; Custom types are also used within Sendbird&#39;s [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.
    * @return customType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.<br /><br /> Custom types are also used within Sendbird's [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -213,7 +213,7 @@ public class OcUpdateChannelByUrlData {
    * Specifies additional channel information such as a long description of the channel or &#x60;JSON&#x60; formatted string.
    * @return data
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies additional channel information such as a long description of the channel or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -244,7 +244,7 @@ public class OcUpdateChannelByUrlData {
    * Specifies an array of one or more user IDs to register as operators of the channel. The maximum allowed number of operators per channel is 100. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.&lt;br/&gt;&lt;br/&gt;  Operators cannot view messages that have been [moderated by](/docs/chat/v3/platform-api/guides/filter-and-moderation) the domain filter or profanity filter. Only the sender will be notified that the message has been blocked.
    * @return operatorIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more user IDs to register as operators of the channel. The maximum allowed number of operators per channel is 100. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.<br/><br/>  Operators cannot view messages that have been [moderated by](/docs/chat/v3/platform-api/guides/filter-and-moderation) the domain filter or profanity filter. Only the sender will be notified that the message has been blocked.")
   @JsonProperty(JSON_PROPERTY_OPERATOR_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -275,7 +275,7 @@ public class OcUpdateChannelByUrlData {
    * (Deprecated) Specifies the string IDs of the users registered as channel operators. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.
    * @return operators
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "(Deprecated) Specifies the string IDs of the users registered as channel operators. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.")
   @JsonProperty(JSON_PROPERTY_OPERATORS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/OcViewBanByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcViewBanByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   OcViewBanByIdResponse.JSON_PROPERTY_START_AT
 })
 @JsonTypeName("ocViewBanByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcViewBanByIdResponse {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;
@@ -66,7 +66,7 @@ public class OcViewBanByIdResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class OcViewBanByIdResponse {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -118,7 +118,7 @@ public class OcViewBanByIdResponse {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -144,7 +144,7 @@ public class OcViewBanByIdResponse {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/OcViewMuteByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcViewMuteByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   OcViewMuteByIdResponse.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("ocViewMuteByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OcViewMuteByIdResponse {
   public static final String JSON_PROPERTY_IS_MUTED = "is_muted";
   private Boolean isMuted;
@@ -69,7 +69,7 @@ public class OcViewMuteByIdResponse {
    * Get isMuted
    * @return isMuted
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_MUTED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -95,7 +95,7 @@ public class OcViewMuteByIdResponse {
    * Get remainingDuration
    * @return remainingDuration
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REMAINING_DURATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -121,7 +121,7 @@ public class OcViewMuteByIdResponse {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -147,7 +147,7 @@ public class OcViewMuteByIdResponse {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -173,7 +173,7 @@ public class OcViewMuteByIdResponse {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RegisterAndScheduleDataExportData.java
+++ b/src/main/java/org/openapitools/client/model/RegisterAndScheduleDataExportData.java
@@ -49,7 +49,7 @@ import org.sendbird.client.JSON;
   RegisterAndScheduleDataExportData.JSON_PROPERTY_NEIGHBORING_MESSAGE_LIMIT
 })
 @JsonTypeName("registerAndScheduleDataExportData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RegisterAndScheduleDataExportData {
   public static final String JSON_PROPERTY_START_TS = "start_ts";
   private Integer startTs;
@@ -102,7 +102,7 @@ public class RegisterAndScheduleDataExportData {
    * Specifies the starting timestamp of a period for target objects&#39; creation date, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. The creation time of messages, channels, and users will be in-between the start_ts and end_ts.
    * @return startTs
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the starting timestamp of a period for target objects' creation date, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. The creation time of messages, channels, and users will be in-between the start_ts and end_ts.")
   @JsonProperty(JSON_PROPERTY_START_TS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -128,7 +128,7 @@ public class RegisterAndScheduleDataExportData {
    * Specifies the ending timestamp of a period for target objects&#39; creation date, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. The creation time of messages, channels, and users will be in-between the start_ts and end_ts.
    * @return endTs
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ending timestamp of a period for target objects' creation date, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. The creation time of messages, channels, and users will be in-between the start_ts and end_ts.")
   @JsonProperty(JSON_PROPERTY_END_TS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -154,7 +154,7 @@ public class RegisterAndScheduleDataExportData {
    * Specifies the format of the file to export the messages to. Acceptable values are json and csv. (Default: json)
    * @return format
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the format of the file to export the messages to. Acceptable values are json and csv. (Default: json)")
   @JsonProperty(JSON_PROPERTY_FORMAT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -180,7 +180,7 @@ public class RegisterAndScheduleDataExportData {
    * Sets a single character delimiter to separate the values in each row of the csv file which stores two-dimensional arrays of the exported message data. Either English alphabets or special characters can be used as a delimiter, including a horizontal tab (\\t), a line feed (\\n), a vertical bar (\\
    * @return csvDelimiter
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Sets a single character delimiter to separate the values in each row of the csv file which stores two-dimensional arrays of the exported message data. Either English alphabets or special characters can be used as a delimiter, including a horizontal tab (\\t), a line feed (\\n), a vertical bar (\\")
   @JsonProperty(JSON_PROPERTY_CSV_DELIMITER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -206,7 +206,7 @@ public class RegisterAndScheduleDataExportData {
    * Specifies the timezone to be applied to the timestamp of the exported messages. For example, US/Pacific, Asia/Seoul, Europe/London, etc. (Default: UTC)
    * @return timezone
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the timezone to be applied to the timestamp of the exported messages. For example, US/Pacific, Asia/Seoul, Europe/London, etc. (Default: UTC)")
   @JsonProperty(JSON_PROPERTY_TIMEZONE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -240,7 +240,7 @@ public class RegisterAndScheduleDataExportData {
    * Specifies an array of the IDs of the users which are used to filter the messages by its sender for the export. This property is effective only when the data_type parameter is set to messages, and can be specified up to 10 IDs in the request. (Default: all messages sent by any user)
    * @return senderIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of the IDs of the users which are used to filter the messages by its sender for the export. This property is effective only when the data_type parameter is set to messages, and can be specified up to 10 IDs in the request. (Default: all messages sent by any user)")
   @JsonProperty(JSON_PROPERTY_SENDER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -274,7 +274,7 @@ public class RegisterAndScheduleDataExportData {
    * Specifies an array of the IDs of the users which are used to exclude their sent messages from the export. This property is effective only when the data_type parameter is set to messages, and can be specified up to 10 IDs. (Default: all messages sent by any user)
    * @return excludeSenderIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of the IDs of the users which are used to exclude their sent messages from the export. This property is effective only when the data_type parameter is set to messages, and can be specified up to 10 IDs. (Default: all messages sent by any user)")
   @JsonProperty(JSON_PROPERTY_EXCLUDE_SENDER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -308,7 +308,7 @@ public class RegisterAndScheduleDataExportData {
    * Specifies an array of one or more URLs of channels to export the messages from. This property is effective only when the data_type parameter is set to messages or channels. (Default: all channels)
    * @return channelUrls
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more URLs of channels to export the messages from. This property is effective only when the data_type parameter is set to messages or channels. (Default: all channels)")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -342,7 +342,7 @@ public class RegisterAndScheduleDataExportData {
    * Specifies an array of one or more URLs of channels to exclude when exporting the messages. This property is effective only when the data_type parameter is set to messages or channels. (Default: include all channels)
    * @return excludeChannelUrls
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more URLs of channels to exclude when exporting the messages. This property is effective only when the data_type parameter is set to messages or channels. (Default: include all channels)")
   @JsonProperty(JSON_PROPERTY_EXCLUDE_CHANNEL_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -376,7 +376,7 @@ public class RegisterAndScheduleDataExportData {
    * Specifies an array of the IDs of the users to export their information. This property is effective only when the data_type parameter is set to users. (Default: all users)
    * @return userIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of the IDs of the users to export their information. This property is effective only when the data_type parameter is set to users. (Default: all users)")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -402,7 +402,7 @@ public class RegisterAndScheduleDataExportData {
    * Determines whether to include information about the read receipts of each channel in the exported data. The read receipt indicates the timestamps of when each user has last read the messages in the channel, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps). (Default: true)
    * @return showReadReceipt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to include information about the read receipts of each channel in the exported data. The read receipt indicates the timestamps of when each user has last read the messages in the channel, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps). (Default: true)")
   @JsonProperty(JSON_PROPERTY_SHOW_READ_RECEIPT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -428,7 +428,7 @@ public class RegisterAndScheduleDataExportData {
    * Determines whether to include [channel metadata](/docs/chat/v3/platform-api/guides/user-and-channel-metadata#2-view-a-channel-metadata) in the result files.
    * @return showChannelMetadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to include [channel metadata](/docs/chat/v3/platform-api/guides/user-and-channel-metadata#2-view-a-channel-metadata) in the result files.")
   @JsonProperty(JSON_PROPERTY_SHOW_CHANNEL_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -454,7 +454,7 @@ public class RegisterAndScheduleDataExportData {
    * Specifies the maximum number of other users&#39; messages to be exported, which took place after the specified message of a user filtered by the sender_ids property. Even if there may be more messages that took place, if the quantity exceeds the number of the neighboring_message_limit, they are omitted. Only the messages that took place right after the specified message will be counted and exported. This can be used to better analyze the context. Acceptable values are 1 to 10, inclusive. (Default: 0)
    * @return neighboringMessageLimit
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the maximum number of other users' messages to be exported, which took place after the specified message of a user filtered by the sender_ids property. Even if there may be more messages that took place, if the quantity exceeds the number of the neighboring_message_limit, they are omitted. Only the messages that took place right after the specified message will be counted and exported. This can be used to better analyze the context. Acceptable values are 1 to 10, inclusive. (Default: 0)")
   @JsonProperty(JSON_PROPERTY_NEIGHBORING_MESSAGE_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RegisterAndScheduleDataExportResponse.java
+++ b/src/main/java/org/openapitools/client/model/RegisterAndScheduleDataExportResponse.java
@@ -52,7 +52,7 @@ import org.sendbird.client.JSON;
   RegisterAndScheduleDataExportResponse.JSON_PROPERTY_USER_IDS
 })
 @JsonTypeName("registerAndScheduleDataExportResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RegisterAndScheduleDataExportResponse {
   public static final String JSON_PROPERTY_CHANNEL_CUSTOM_TYPES = "channel_custom_types";
   private List<String> channelCustomTypes = null;
@@ -116,7 +116,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get channelCustomTypes
    * @return channelCustomTypes
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_CUSTOM_TYPES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -142,7 +142,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get dataType
    * @return dataType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -168,7 +168,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get requestId
    * @return requestId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUEST_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -194,7 +194,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -220,7 +220,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get format
    * @return format
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FORMAT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -246,7 +246,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get csvDelimiter
    * @return csvDelimiter
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CSV_DELIMITER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -272,7 +272,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get timezone
    * @return timezone
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TIMEZONE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -298,7 +298,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -324,7 +324,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get startTs
    * @return startTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -350,7 +350,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get endTs
    * @return endTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -384,7 +384,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get channelUrls
    * @return channelUrls
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -418,7 +418,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get senderIds
    * @return senderIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENDER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -444,7 +444,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get _file
    * @return _file
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -478,7 +478,7 @@ public class RegisterAndScheduleDataExportResponse {
    * Get userIds
    * @return userIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RegisterAsOperatorToChannelsWithCustomChannelTypesData.java
+++ b/src/main/java/org/openapitools/client/model/RegisterAsOperatorToChannelsWithCustomChannelTypesData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   RegisterAsOperatorToChannelsWithCustomChannelTypesData.JSON_PROPERTY_CHANNEL_CUSTOM_TYPES
 })
 @JsonTypeName("registerAsOperatorToChannelsWithCustomChannelTypesData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RegisterAsOperatorToChannelsWithCustomChannelTypesData {
   public static final String JSON_PROPERTY_CHANNEL_CUSTOM_TYPES = "channel_custom_types";
   private List<String> channelCustomTypes = new ArrayList<>();
@@ -59,7 +59,7 @@ public class RegisterAsOperatorToChannelsWithCustomChannelTypesData {
    * Specifies an array of one or more custom channel types, in order to register the user as an operator to channels with the channel types.
    * @return channelCustomTypes
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more custom channel types, in order to register the user as an operator to channels with the channel types.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_CUSTOM_TYPES)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/RegisterGdprRequestData.java
+++ b/src/main/java/org/openapitools/client/model/RegisterGdprRequestData.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   RegisterGdprRequestData.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("registerGdprRequestData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RegisterGdprRequestData {
   public static final String JSON_PROPERTY_ACTION = "action";
   private String action;
@@ -66,7 +66,7 @@ public class RegisterGdprRequestData {
    * Determines the type of a GDPR request. Acceptable values are limited to access and delete. If set to access, Sendbird server generates a downloadable zip file containing the data of the specified user with the user_id property to comply with GDPR&#39;s [right to access](https://gdpr-info.eu/art-15-gdpr/) of the data subject. If set to delete, the specified users with the user_ids property will be permanently deleted from your Sendbird application to comply with GDPR&#39;s [right to erasure](https://gdpr-info.eu/art-17-gdpr/) of the data subject. (Default: delete)
    * @return action
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines the type of a GDPR request. Acceptable values are limited to access and delete. If set to access, Sendbird server generates a downloadable zip file containing the data of the specified user with the user_id property to comply with GDPR's [right to access](https://gdpr-info.eu/art-15-gdpr/) of the data subject. If set to delete, the specified users with the user_ids property will be permanently deleted from your Sendbird application to comply with GDPR's [right to erasure](https://gdpr-info.eu/art-17-gdpr/) of the data subject. (Default: delete)")
   @JsonProperty(JSON_PROPERTY_ACTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -97,7 +97,7 @@ public class RegisterGdprRequestData {
    * Specifies an array of the IDs of the users to delete in order to meet the GDPR&#39;s requirements. The maximum number of users to be processed at once is 100. This should be specified when the value of the action property is delete.
    * @return userIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of the IDs of the users to delete in order to meet the GDPR's requirements. The maximum number of users to be processed at once is 100. This should be specified when the value of the action property is delete.")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -123,7 +123,7 @@ public class RegisterGdprRequestData {
    * Determines the scope of group channels to delete in addition to deleting the specified users with the user_ids property. Acceptable values are limited to the following:&lt;br /&gt;- do_not_delete (default): the users will be deleted but their joined group channels will remain.&lt;br /&gt;- 1_on_1: only 1-on-1 group channels of the users will be deleted. (This option can be useful when eliminating spam users) &lt;br /&gt;- all: all joined group channels of the users will be deleted.&lt;br /&gt;&lt;br /&gt; This only works when the value of the action property is delete.
    * @return channelDeleteOption
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines the scope of group channels to delete in addition to deleting the specified users with the user_ids property. Acceptable values are limited to the following:<br />- do_not_delete (default): the users will be deleted but their joined group channels will remain.<br />- 1_on_1: only 1-on-1 group channels of the users will be deleted. (This option can be useful when eliminating spam users) <br />- all: all joined group channels of the users will be deleted.<br /><br /> This only works when the value of the action property is delete.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_DELETE_OPTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -149,7 +149,7 @@ public class RegisterGdprRequestData {
    * Specifies the ID of the user to meet the GDPR&#39;s requirements.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the user to meet the GDPR's requirements.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/RegisterGdprRequestResponse.java
+++ b/src/main/java/org/openapitools/client/model/RegisterGdprRequestResponse.java
@@ -44,7 +44,7 @@ import org.sendbird.client.JSON;
   RegisterGdprRequestResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("registerGdprRequestResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RegisterGdprRequestResponse {
   public static final String JSON_PROPERTY_REQUEST_ID = "request_id";
   private String requestId;
@@ -79,7 +79,7 @@ public class RegisterGdprRequestResponse {
    * Get requestId
    * @return requestId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUEST_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -105,7 +105,7 @@ public class RegisterGdprRequestResponse {
    * Get action
    * @return action
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ACTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -131,7 +131,7 @@ public class RegisterGdprRequestResponse {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -157,7 +157,7 @@ public class RegisterGdprRequestResponse {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -191,7 +191,7 @@ public class RegisterGdprRequestResponse {
    * Get userIds
    * @return userIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -217,7 +217,7 @@ public class RegisterGdprRequestResponse {
    * Get channelDeleteOption
    * @return channelDeleteOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_DELETE_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -243,7 +243,7 @@ public class RegisterGdprRequestResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RemovePushConfigurationByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/RemovePushConfigurationByIdResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   RemovePushConfigurationByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("removePushConfigurationByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RemovePushConfigurationByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<String> pushConfigurations = null;
@@ -62,7 +62,7 @@ public class RemovePushConfigurationByIdResponse {
    * Get pushConfigurations
    * @return pushConfigurations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_CONFIGURATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RemoveReactionFromAMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/RemoveReactionFromAMessageResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   RemoveReactionFromAMessageResponse.JSON_PROPERTY_OPERATION
 })
 @JsonTypeName("removeReactionFromAMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RemoveReactionFromAMessageResponse {
   public static final String JSON_PROPERTY_REACTION = "reaction";
   private String reaction;
@@ -73,7 +73,7 @@ public class RemoveReactionFromAMessageResponse {
    * Get reaction
    * @return reaction
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REACTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -99,7 +99,7 @@ public class RemoveReactionFromAMessageResponse {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -125,7 +125,7 @@ public class RemoveReactionFromAMessageResponse {
    * Get success
    * @return success
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SUCCESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -151,7 +151,7 @@ public class RemoveReactionFromAMessageResponse {
    * Get msgId
    * @return msgId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MSG_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -177,7 +177,7 @@ public class RemoveReactionFromAMessageResponse {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -203,7 +203,7 @@ public class RemoveReactionFromAMessageResponse {
    * Get operation
    * @return operation
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPERATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenByTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenByTokenResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   RemoveRegistrationOrDeviceTokenByTokenResponse.JSON_PROPERTY_USER
 })
 @JsonTypeName("removeRegistrationOrDeviceTokenByTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RemoveRegistrationOrDeviceTokenByTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private List<String> token = null;
@@ -67,7 +67,7 @@ public class RemoveRegistrationOrDeviceTokenByTokenResponse {
    * Get token
    * @return token
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class RemoveRegistrationOrDeviceTokenByTokenResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenFromOwnerByTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenFromOwnerByTokenResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   RemoveRegistrationOrDeviceTokenFromOwnerByTokenResponse.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("removeRegistrationOrDeviceTokenFromOwnerByTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RemoveRegistrationOrDeviceTokenFromOwnerByTokenResponse {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -52,7 +52,7 @@ public class RemoveRegistrationOrDeviceTokenFromOwnerByTokenResponse {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   RemoveRegistrationOrDeviceTokenResponse.JSON_PROPERTY_USER
 })
 @JsonTypeName("removeRegistrationOrDeviceTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RemoveRegistrationOrDeviceTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private List<String> token = null;
@@ -67,7 +67,7 @@ public class RemoveRegistrationOrDeviceTokenResponse {
    * Get token
    * @return token
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class RemoveRegistrationOrDeviceTokenResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ReportChannelByUrlData.java
+++ b/src/main/java/org/openapitools/client/model/ReportChannelByUrlData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ReportChannelByUrlData.JSON_PROPERTY_REPORT_DESCRIPTION
 })
 @JsonTypeName("reportChannelByUrlData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ReportChannelByUrlData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;
@@ -68,7 +68,7 @@ public class ReportChannelByUrlData {
    * Specifies the type of the channel. Either open_channels or group_channels.
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the type of the channel. Either open_channels or group_channels.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class ReportChannelByUrlData {
    * Specifies the URL of the channel to report for offensive messages or inappropriate activities.
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the channel to report for offensive messages or inappropriate activities.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -120,7 +120,7 @@ public class ReportChannelByUrlData {
    * Specifies the category which indicates the reason for reporting. Acceptable values are suspicious, harassing, inappropriate, and spam.
    * @return reportCategory
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the category which indicates the reason for reporting. Acceptable values are suspicious, harassing, inappropriate, and spam.")
   @JsonProperty(JSON_PROPERTY_REPORT_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -146,7 +146,7 @@ public class ReportChannelByUrlData {
    * Specifies the unique ID of the user who reports the channel.
    * @return reportingUserId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of the user who reports the channel.")
   @JsonProperty(JSON_PROPERTY_REPORTING_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -172,7 +172,7 @@ public class ReportChannelByUrlData {
    * Specifies additional information to be included in the report.
    * @return reportDescription
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional information to be included in the report.")
   @JsonProperty(JSON_PROPERTY_REPORT_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ReportChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/ReportChannelByUrlResponse.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ReportChannelByUrlResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("reportChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ReportChannelByUrlResponse {
   public static final String JSON_PROPERTY_REPORT_TYPE = "report_type";
   private String reportType;
@@ -88,7 +88,7 @@ public class ReportChannelByUrlResponse {
    * Get reportType
    * @return reportType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -114,7 +114,7 @@ public class ReportChannelByUrlResponse {
    * Get reportCategory
    * @return reportCategory
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -140,7 +140,7 @@ public class ReportChannelByUrlResponse {
    * Get reportingUser
    * @return reportingUser
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORTING_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -166,7 +166,7 @@ public class ReportChannelByUrlResponse {
    * Get offendingUser
    * @return offendingUser
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OFFENDING_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -192,7 +192,7 @@ public class ReportChannelByUrlResponse {
    * Get reportedMessage
    * @return reportedMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -226,7 +226,7 @@ public class ReportChannelByUrlResponse {
    * Get channel
    * @return channel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -252,7 +252,7 @@ public class ReportChannelByUrlResponse {
    * Get reportDescription
    * @return reportDescription
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -278,7 +278,7 @@ public class ReportChannelByUrlResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ReportMessageByIdData.java
+++ b/src/main/java/org/openapitools/client/model/ReportMessageByIdData.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   ReportMessageByIdData.JSON_PROPERTY_REPORT_DESCRIPTION
 })
 @JsonTypeName("reportMessageByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ReportMessageByIdData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;
@@ -76,7 +76,7 @@ public class ReportMessageByIdData {
    * Specifies the type of the channel. Either open_channels or group_channels.
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the type of the channel. Either open_channels or group_channels.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -102,7 +102,7 @@ public class ReportMessageByIdData {
    * Specifies the URL of the channel where the message to report is in.
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the channel where the message to report is in.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -128,7 +128,7 @@ public class ReportMessageByIdData {
    * Specifies the unique ID of the message to report.
    * @return messageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of the message to report.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -154,7 +154,7 @@ public class ReportMessageByIdData {
    * Specifies the category which indicates the reason for reporting. Acceptable values are suspicious, harassing, inappropriate, and spam.
    * @return reportCategory
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the category which indicates the reason for reporting. Acceptable values are suspicious, harassing, inappropriate, and spam.")
   @JsonProperty(JSON_PROPERTY_REPORT_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -180,7 +180,7 @@ public class ReportMessageByIdData {
    * Specifies the unique ID of the user who has sent the message to report.
    * @return offendingUserId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the user who has sent the message to report.")
   @JsonProperty(JSON_PROPERTY_OFFENDING_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -206,7 +206,7 @@ public class ReportMessageByIdData {
    * Specifies the unique ID of the user who reports the message.
    * @return reportingUserId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of the user who reports the message.")
   @JsonProperty(JSON_PROPERTY_REPORTING_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -232,7 +232,7 @@ public class ReportMessageByIdData {
    * Specifies additional information to be included in the report.
    * @return reportDescription
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional information to be included in the report.")
   @JsonProperty(JSON_PROPERTY_REPORT_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ReportMessageByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ReportMessageByIdResponse.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ReportMessageByIdResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("reportMessageByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ReportMessageByIdResponse {
   public static final String JSON_PROPERTY_REPORT_TYPE = "report_type";
   private String reportType;
@@ -88,7 +88,7 @@ public class ReportMessageByIdResponse {
    * Get reportType
    * @return reportType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -114,7 +114,7 @@ public class ReportMessageByIdResponse {
    * Get reportCategory
    * @return reportCategory
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -140,7 +140,7 @@ public class ReportMessageByIdResponse {
    * Get reportingUser
    * @return reportingUser
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORTING_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -166,7 +166,7 @@ public class ReportMessageByIdResponse {
    * Get offendingUser
    * @return offendingUser
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OFFENDING_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -192,7 +192,7 @@ public class ReportMessageByIdResponse {
    * Get reportedMessage
    * @return reportedMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -226,7 +226,7 @@ public class ReportMessageByIdResponse {
    * Get channel
    * @return channel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -252,7 +252,7 @@ public class ReportMessageByIdResponse {
    * Get reportDescription
    * @return reportDescription
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -278,7 +278,7 @@ public class ReportMessageByIdResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ReportUserByIdData.java
+++ b/src/main/java/org/openapitools/client/model/ReportUserByIdData.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   ReportUserByIdData.JSON_PROPERTY_REPORT_DESCRIPTION
 })
 @JsonTypeName("reportUserByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ReportUserByIdData {
   public static final String JSON_PROPERTY_OFFENDING_USER_ID = "offending_user_id";
   private String offendingUserId;
@@ -72,7 +72,7 @@ public class ReportUserByIdData {
    * Specifies the unique ID of the user to report for using offensive or abusive language such as sending explicit messages or inappropriate comments.
    * @return offendingUserId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the user to report for using offensive or abusive language such as sending explicit messages or inappropriate comments.")
   @JsonProperty(JSON_PROPERTY_OFFENDING_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -98,7 +98,7 @@ public class ReportUserByIdData {
    * Specifies the type of the channel. Either open_channels or group_channels.
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the type of the channel. Either open_channels or group_channels.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class ReportUserByIdData {
    * Specifies the URL of the channel where the user to report is in.
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the channel where the user to report is in.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -150,7 +150,7 @@ public class ReportUserByIdData {
    * Specifies the category which indicates the reason for reporting. Acceptable values are suspicious, harassing, inappropriate, and spam.
    * @return reportCategory
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the category which indicates the reason for reporting. Acceptable values are suspicious, harassing, inappropriate, and spam.")
   @JsonProperty(JSON_PROPERTY_REPORT_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -176,7 +176,7 @@ public class ReportUserByIdData {
    * Specifies the unique ID of the user who reports the offending user.
    * @return reportingUserId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of the user who reports the offending user.")
   @JsonProperty(JSON_PROPERTY_REPORTING_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -202,7 +202,7 @@ public class ReportUserByIdData {
    * Specifies additional information to be included in the report.
    * @return reportDescription
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional information to be included in the report.")
   @JsonProperty(JSON_PROPERTY_REPORT_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ReportUserByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ReportUserByIdResponse.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ReportUserByIdResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("reportUserByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ReportUserByIdResponse {
   public static final String JSON_PROPERTY_REPORT_TYPE = "report_type";
   private String reportType;
@@ -88,7 +88,7 @@ public class ReportUserByIdResponse {
    * Get reportType
    * @return reportType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -114,7 +114,7 @@ public class ReportUserByIdResponse {
    * Get reportCategory
    * @return reportCategory
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -140,7 +140,7 @@ public class ReportUserByIdResponse {
    * Get reportingUser
    * @return reportingUser
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORTING_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -166,7 +166,7 @@ public class ReportUserByIdResponse {
    * Get offendingUser
    * @return offendingUser
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OFFENDING_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -192,7 +192,7 @@ public class ReportUserByIdResponse {
    * Get reportedMessage
    * @return reportedMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -226,7 +226,7 @@ public class ReportUserByIdResponse {
    * Get channel
    * @return channel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -252,7 +252,7 @@ public class ReportUserByIdResponse {
    * Get reportDescription
    * @return reportDescription
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPORT_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -278,7 +278,7 @@ public class ReportUserByIdResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ResetPushPreferencesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ResetPushPreferencesResponse.java
@@ -51,7 +51,7 @@ import org.sendbird.client.JSON;
   ResetPushPreferencesResponse.JSON_PROPERTY_PUSH_TRIGGER_OPTION
 })
 @JsonTypeName("resetPushPreferencesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ResetPushPreferencesResponse {
   public static final String JSON_PROPERTY_SNOOZE_START_TS = "snooze_start_ts";
   private String snoozeStartTs;
@@ -107,7 +107,7 @@ public class ResetPushPreferencesResponse {
    * Get snoozeStartTs
    * @return snoozeStartTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_START_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -133,7 +133,7 @@ public class ResetPushPreferencesResponse {
    * Get startHour
    * @return startHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -159,7 +159,7 @@ public class ResetPushPreferencesResponse {
    * Get snoozeEnabled
    * @return snoozeEnabled
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -185,7 +185,7 @@ public class ResetPushPreferencesResponse {
    * Get endMin
    * @return endMin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -211,7 +211,7 @@ public class ResetPushPreferencesResponse {
    * Get timezone
    * @return timezone
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TIMEZONE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -237,7 +237,7 @@ public class ResetPushPreferencesResponse {
    * Get blockPushFromBots
    * @return blockPushFromBots
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BLOCK_PUSH_FROM_BOTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -271,7 +271,7 @@ public class ResetPushPreferencesResponse {
    * Get pushBlockedBotIds
    * @return pushBlockedBotIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_BLOCKED_BOT_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -297,7 +297,7 @@ public class ResetPushPreferencesResponse {
    * Get startMin
    * @return startMin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -323,7 +323,7 @@ public class ResetPushPreferencesResponse {
    * Get snoozeEndTs
    * @return snoozeEndTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_END_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -349,7 +349,7 @@ public class ResetPushPreferencesResponse {
    * Get doNotDisturb
    * @return doNotDisturb
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DO_NOT_DISTURB)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -375,7 +375,7 @@ public class ResetPushPreferencesResponse {
    * Get endHour
    * @return endHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -401,7 +401,7 @@ public class ResetPushPreferencesResponse {
    * Get enablePushForReplies
    * @return enablePushForReplies
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_PUSH_FOR_REPLIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -427,7 +427,7 @@ public class ResetPushPreferencesResponse {
    * Get pushSound
    * @return pushSound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -453,7 +453,7 @@ public class ResetPushPreferencesResponse {
    * Get pushTriggerOption
    * @return pushTriggerOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_TRIGGER_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RetrieveAdvancedAnalyticsMetricsResponse.java
+++ b/src/main/java/org/openapitools/client/model/RetrieveAdvancedAnalyticsMetricsResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   RetrieveAdvancedAnalyticsMetricsResponse.JSON_PROPERTY_CUSTOM_MESSAGE_TYPE
 })
 @JsonTypeName("retrieveAdvancedAnalyticsMetricsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RetrieveAdvancedAnalyticsMetricsResponse {
   public static final String JSON_PROPERTY_SEGMENTS = "segments";
   private String segments;
@@ -73,7 +73,7 @@ public class RetrieveAdvancedAnalyticsMetricsResponse {
    * Get segments
    * @return segments
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SEGMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -99,7 +99,7 @@ public class RetrieveAdvancedAnalyticsMetricsResponse {
    * Get date
    * @return date
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -125,7 +125,7 @@ public class RetrieveAdvancedAnalyticsMetricsResponse {
    * Get value
    * @return value
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VALUE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -151,7 +151,7 @@ public class RetrieveAdvancedAnalyticsMetricsResponse {
    * Get channelType
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -177,7 +177,7 @@ public class RetrieveAdvancedAnalyticsMetricsResponse {
    * Get customChannelType
    * @return customChannelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -203,7 +203,7 @@ public class RetrieveAdvancedAnalyticsMetricsResponse {
    * Get customMessageType
    * @return customMessageType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_MESSAGE_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RetrieveIpWhitelistResponse.java
+++ b/src/main/java/org/openapitools/client/model/RetrieveIpWhitelistResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   RetrieveIpWhitelistResponse.JSON_PROPERTY_IP_WHITELIST_ADDRESSES
 })
 @JsonTypeName("retrieveIpWhitelistResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RetrieveIpWhitelistResponse {
   public static final String JSON_PROPERTY_IP_WHITELIST_ADDRESSES = "ip_whitelist_addresses";
   private List<String> ipWhitelistAddresses = null;
@@ -62,7 +62,7 @@ public class RetrieveIpWhitelistResponse {
    * Get ipWhitelistAddresses
    * @return ipWhitelistAddresses
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IP_WHITELIST_ADDRESSES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RetrieveListOfSubscribedEventsResponse.java
+++ b/src/main/java/org/openapitools/client/model/RetrieveListOfSubscribedEventsResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   RetrieveListOfSubscribedEventsResponse.JSON_PROPERTY_WEBHOOK
 })
 @JsonTypeName("retrieveListOfSubscribedEventsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RetrieveListOfSubscribedEventsResponse {
   public static final String JSON_PROPERTY_WEBHOOK = "webhook";
   private RetrieveListOfSubscribedEventsResponseWebhook webhook;
@@ -53,7 +53,7 @@ public class RetrieveListOfSubscribedEventsResponse {
    * Get webhook
    * @return webhook
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_WEBHOOK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RetrieveListOfSubscribedEventsResponseWebhook.java
+++ b/src/main/java/org/openapitools/client/model/RetrieveListOfSubscribedEventsResponseWebhook.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   RetrieveListOfSubscribedEventsResponseWebhook.JSON_PROPERTY_INCLUDE_UNREAD_COUNT
 })
 @JsonTypeName("retrieveListOfSubscribedEventsResponse_webhook")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RetrieveListOfSubscribedEventsResponseWebhook {
   public static final String JSON_PROPERTY_ENABLED = "enabled";
   private Boolean enabled;
@@ -74,7 +74,7 @@ public class RetrieveListOfSubscribedEventsResponseWebhook {
    * Get enabled
    * @return enabled
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -100,7 +100,7 @@ public class RetrieveListOfSubscribedEventsResponseWebhook {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -126,7 +126,7 @@ public class RetrieveListOfSubscribedEventsResponseWebhook {
    * Get includeMembers
    * @return includeMembers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_INCLUDE_MEMBERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -160,7 +160,7 @@ public class RetrieveListOfSubscribedEventsResponseWebhook {
    * Get enabledEvents
    * @return enabledEvents
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLED_EVENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -194,7 +194,7 @@ public class RetrieveListOfSubscribedEventsResponseWebhook {
    * Get allWebhookCategories
    * @return allWebhookCategories
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ALL_WEBHOOK_CATEGORIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -220,7 +220,7 @@ public class RetrieveListOfSubscribedEventsResponseWebhook {
    * Get includeUnreadCount
    * @return includeUnreadCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_INCLUDE_UNREAD_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/RevokeSecondaryApiTokenByTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/RevokeSecondaryApiTokenByTokenResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   RevokeSecondaryApiTokenByTokenResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("revokeSecondaryApiTokenByTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class RevokeSecondaryApiTokenByTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;
@@ -57,7 +57,7 @@ public class RevokeSecondaryApiTokenByTokenResponse {
    * Get token
    * @return token
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class RevokeSecondaryApiTokenByTokenResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SBObject.java
+++ b/src/main/java/org/openapitools/client/model/SBObject.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
 @JsonPropertyOrder({
   SBObject.JSON_PROPERTY_CONSTRUCTOR
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SBObject {
   public static final String JSON_PROPERTY_CONSTRUCTOR = "constructor";
   private Function constructor;
@@ -52,7 +52,7 @@ public class SBObject {
    * Get constructor
    * @return constructor
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CONSTRUCTOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ScheduleAnnouncementData.java
+++ b/src/main/java/org/openapitools/client/model/ScheduleAnnouncementData.java
@@ -61,7 +61,7 @@ import org.sendbird.client.JSON;
   ScheduleAnnouncementData.JSON_PROPERTY_ASSIGN_SENDER_AS_CHANNEL_INVITER
 })
 @JsonTypeName("scheduleAnnouncementData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ScheduleAnnouncementData {
   public static final String JSON_PROPERTY_MESSAGE = "message";
   private ScheduleAnnouncementDataMessage message;
@@ -147,7 +147,7 @@ public class ScheduleAnnouncementData {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -173,7 +173,7 @@ public class ScheduleAnnouncementData {
    * Specifies the type of the message, which can be either MESG for a text message and ADMM for an admin message.
    * @return messageType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the type of the message, which can be either MESG for a text message and ADMM for an admin message.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -199,7 +199,7 @@ public class ScheduleAnnouncementData {
    * Specifies the unique ID of the sender when the message.type is MESG. When the message.type value is ADMM, this property is not effective.
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of the sender when the message.type is MESG. When the message.type value is ADMM, this property is not effective.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -225,7 +225,7 @@ public class ScheduleAnnouncementData {
    * Specifies the content of the message.
    * @return content
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the content of the message.")
   @JsonProperty(JSON_PROPERTY_CONTENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -251,7 +251,7 @@ public class ScheduleAnnouncementData {
    * Specifies the target channels to send the announcement to. Acceptable values are the following: &lt;br/&gt; - sender_all_channels (Default): sends the announcement to all of the sender&#39;s group channels.&lt;br /&gt;- target_channels: sends the announcement to all target group channels. When the &#x60;message.type&#x60; of the announcement is ADMM, this is the only valid option. &lt;br /&gt; - target_users_included_channels: sends the announcement to group channels consisting of the sender, target users, and other members. &lt;br/&gt; - target_users_only_channels: sends the announcement to group channels consisting of the sender and target users only.
    * @return targetAt
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the target channels to send the announcement to. Acceptable values are the following: <br/> - sender_all_channels (Default): sends the announcement to all of the sender's group channels.<br />- target_channels: sends the announcement to all target group channels. When the `message.type` of the announcement is ADMM, this is the only valid option. <br /> - target_users_included_channels: sends the announcement to group channels consisting of the sender, target users, and other members. <br/> - target_users_only_channels: sends the announcement to group channels consisting of the sender and target users only.")
   @JsonProperty(JSON_PROPERTY_TARGET_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -282,7 +282,7 @@ public class ScheduleAnnouncementData {
    * Specifies an array of one or more target user IDs or target channel URLs to send the announcement to when the target_at is  target_channels, target_users_only_channels, or target_users_included_channels.&lt;br /&gt;&lt;br /&gt;  When the target_at value is sender_all_channels, this property is not effective.
    * @return targetList
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more target user IDs or target channel URLs to send the announcement to when the target_at is  target_channels, target_users_only_channels, or target_users_included_channels.<br /><br />  When the target_at value is sender_all_channels, this property is not effective.")
   @JsonProperty(JSON_PROPERTY_TARGET_LIST)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -308,7 +308,7 @@ public class ScheduleAnnouncementData {
    * Determines which type of group channel to send the announcement to, based on the target_at and target_list. This property is effective only when the target_at is either target_users_only_channels or target_users_included_channels and the target_list is specified. Acceptable values are limited to the following:&lt;br/&gt;- all: send the announcement to all channels that have all target users and the sender in them, regardless of channel type.&lt;br/&gt;- distinct (default): sends this announcement to the distinct channels. Distinct channels continue to use the same existing channels whenever someone attempts to create a new channel with the same members.&lt;br/&gt;- non-distinct: sends this announcement to the non-distinct channels. Non-distinct channels always create a new channel even if there is an existing channel with the same members.&lt;br/&gt;&lt;br/&gt; The distinct and non-distinct channels are a subtype of group channels, determined by the [is_distinct](/docs/chat/v3/platform-api/guides/group-channel#2-types-of-a-channel-3-resource-representation) property.
    * @return targetChannelType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines which type of group channel to send the announcement to, based on the target_at and target_list. This property is effective only when the target_at is either target_users_only_channels or target_users_included_channels and the target_list is specified. Acceptable values are limited to the following:<br/>- all: send the announcement to all channels that have all target users and the sender in them, regardless of channel type.<br/>- distinct (default): sends this announcement to the distinct channels. Distinct channels continue to use the same existing channels whenever someone attempts to create a new channel with the same members.<br/>- non-distinct: sends this announcement to the non-distinct channels. Non-distinct channels always create a new channel even if there is an existing channel with the same members.<br/><br/> The distinct and non-distinct channels are a subtype of group channels, determined by the [is_distinct](/docs/chat/v3/platform-api/guides/group-channel#2-types-of-a-channel-3-resource-representation) property.")
   @JsonProperty(JSON_PROPERTY_TARGET_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -334,7 +334,7 @@ public class ScheduleAnnouncementData {
    * Specifies the unique ID of the new announcement. The unique_id will be automatically created unless specified.
    * @return uniqueId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of the new announcement. The unique_id will be automatically created unless specified.")
   @JsonProperty(JSON_PROPERTY_UNIQUE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -360,7 +360,7 @@ public class ScheduleAnnouncementData {
    * Specifies the custom message type of the message of the new announcement.
    * @return messageCustomType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the custom message type of the message of the new announcement.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -386,7 +386,7 @@ public class ScheduleAnnouncementData {
    * Specifies additional message information such as custom font size, font type or &#x60;JSON&#x60; formatted string.
    * @return messageData
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional message information such as custom font size, font type or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -412,7 +412,7 @@ public class ScheduleAnnouncementData {
    * Determines whether to create a new channel if there is no existing channel that matches with the target options including target_at and target_list. By specifying the create_channel_options, you can configure the properties of newly created channels. (Default: false)
    * @return createChannel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to create a new channel if there is no existing channel that matches with the target options including target_at and target_list. By specifying the create_channel_options, you can configure the properties of newly created channels. (Default: false)")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -438,7 +438,7 @@ public class ScheduleAnnouncementData {
    * Specifies the announcement group that the new announcement belongs to.&lt;br/&gt; &lt;br/&gt; This property is effective only when the target_at is either target_users_only_channels or target_users_included_channels.
    * @return announcementGroup
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the announcement group that the new announcement belongs to.<br/> <br/> This property is effective only when the target_at is either target_users_only_channels or target_users_included_channels.")
   @JsonProperty(JSON_PROPERTY_ANNOUNCEMENT_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -464,7 +464,7 @@ public class ScheduleAnnouncementData {
    * A newly created channel configuration.
    * @return createChannelOptions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "A newly created channel configuration.")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -490,7 +490,7 @@ public class ScheduleAnnouncementData {
    * Specifies the name of channels to be created. (Default: Group Channel)
    * @return createChannelOptionsName
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the name of channels to be created. (Default: Group Channel)")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -516,7 +516,7 @@ public class ScheduleAnnouncementData {
    * Specifies the URL of the cover image for the new channels.
    * @return createChannelOptionsCoverUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the cover image for the new channels.")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -542,7 +542,7 @@ public class ScheduleAnnouncementData {
    * Specifies the custom channel type of the new channels.
    * @return createChannelOptionsCustomType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the custom channel type of the new channels.")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -568,7 +568,7 @@ public class ScheduleAnnouncementData {
    * Specifies additional channel information such as a long description of the channel or &#x60;JSON&#x60; formatted string.
    * @return createChannelOptionsData
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional channel information such as a long description of the channel or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -594,7 +594,7 @@ public class ScheduleAnnouncementData {
    * Determines whether to create a [distinct](/docs/chat/v3/platform-api/guides/channel-types#2-group-channel) channel. (Default: true)
    * @return createChannelOptionsDistinct
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to create a [distinct](/docs/chat/v3/platform-api/guides/channel-types#2-group-channel) channel. (Default: true)")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS_DISTINCT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -620,7 +620,7 @@ public class ScheduleAnnouncementData {
    * Specifies the time to start the announcement, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. If not specified, the default is the timestamp of when the request was delivered to Sendbird server. (Default: current timestamp)
    * @return scheduledAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time to start the announcement, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. If not specified, the default is the timestamp of when the request was delivered to Sendbird server. (Default: current timestamp)")
   @JsonProperty(JSON_PROPERTY_SCHEDULED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -646,7 +646,7 @@ public class ScheduleAnnouncementData {
    * Specifies the time to temporarily put the announcement on hold in UTC. The string is represented in HHMM format. This should be specified in conjunction with the resume_at property.&lt;br/&gt;&lt;br/&gt; If both the cease_at and resume_at are not specified, Sendbird server starts to send the announcement at the time of the scheduled_at above.
    * @return ceaseAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time to temporarily put the announcement on hold in UTC. The string is represented in HHMM format. This should be specified in conjunction with the resume_at property.<br/><br/> If both the cease_at and resume_at are not specified, Sendbird server starts to send the announcement at the time of the scheduled_at above.")
   @JsonProperty(JSON_PROPERTY_CEASE_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -672,7 +672,7 @@ public class ScheduleAnnouncementData {
    * Specifies the time to automatically resume the on-hold announcement in UTC. The string is represented in HHMM format. This should be specified in conjunction with the cease_at property above.&lt;br/&gt;&lt;br/&gt; If both the cease_at and resume_at are not specified, Sendbird server starts to send the announcement at the time of the scheduled_at above.
    * @return resumeAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time to automatically resume the on-hold announcement in UTC. The string is represented in HHMM format. This should be specified in conjunction with the cease_at property above.<br/><br/> If both the cease_at and resume_at are not specified, Sendbird server starts to send the announcement at the time of the scheduled_at above.")
   @JsonProperty(JSON_PROPERTY_RESUME_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -698,7 +698,7 @@ public class ScheduleAnnouncementData {
    * Specifies the time to permanently end the announcement, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous##2-timestamps) format. If this property is specified, the announcement ends even when the announcement is not sent to all its targets. &lt;br/&gt;&lt;br/&gt; For the announcement to run safely, the end_at time should be set at least 10 minutes later than the scheduled_at time.
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time to permanently end the announcement, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous##2-timestamps) format. If this property is specified, the announcement ends even when the announcement is not sent to all its targets. <br/><br/> For the announcement to run safely, the end_at time should be set at least 10 minutes later than the scheduled_at time.")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -724,7 +724,7 @@ public class ScheduleAnnouncementData {
    * Determines whether to turn on push notification for the announcement. If set to true, push notifications will be sent for the announcement. (Default: true)
    * @return enablePush
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to turn on push notification for the announcement. If set to true, push notifications will be sent for the announcement. (Default: true)")
   @JsonProperty(JSON_PROPERTY_ENABLE_PUSH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -750,7 +750,7 @@ public class ScheduleAnnouncementData {
    * Determines whether to assign an announcement sender as an inviter of the newly created channels. (Default: false)
    * @return assignSenderAsChannelInviter
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to assign an announcement sender as an inviter of the newly created channels. (Default: false)")
   @JsonProperty(JSON_PROPERTY_ASSIGN_SENDER_AS_CHANNEL_INVITER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ScheduleAnnouncementDataMessage.java
+++ b/src/main/java/org/openapitools/client/model/ScheduleAnnouncementDataMessage.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ScheduleAnnouncementDataMessage.JSON_PROPERTY_CONTENT
 })
 @JsonTypeName("scheduleAnnouncementData_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ScheduleAnnouncementDataMessage {
   public static final String JSON_PROPERTY_TYPE = "type";
   private String type;
@@ -61,7 +61,7 @@ public class ScheduleAnnouncementDataMessage {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -87,7 +87,7 @@ public class ScheduleAnnouncementDataMessage {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -113,7 +113,7 @@ public class ScheduleAnnouncementDataMessage {
    * Get content
    * @return content
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CONTENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponse.java
+++ b/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponse.java
@@ -55,7 +55,7 @@ import org.sendbird.client.JSON;
   ScheduleAnnouncementResponse.JSON_PROPERTY_OPEN_RATE
 })
 @JsonTypeName("scheduleAnnouncementResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ScheduleAnnouncementResponse {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;
@@ -123,7 +123,7 @@ public class ScheduleAnnouncementResponse {
    * Get uniqueId
    * @return uniqueId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNIQUE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -149,7 +149,7 @@ public class ScheduleAnnouncementResponse {
    * Get announcementGroup
    * @return announcementGroup
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ANNOUNCEMENT_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -175,7 +175,7 @@ public class ScheduleAnnouncementResponse {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -201,7 +201,7 @@ public class ScheduleAnnouncementResponse {
    * Get enablePush
    * @return enablePush
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_PUSH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -227,7 +227,7 @@ public class ScheduleAnnouncementResponse {
    * Get targetAt
    * @return targetAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -253,7 +253,7 @@ public class ScheduleAnnouncementResponse {
    * Get targetUserCount
    * @return targetUserCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_USER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -279,7 +279,7 @@ public class ScheduleAnnouncementResponse {
    * Get targetChannelCount
    * @return targetChannelCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_CHANNEL_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -305,7 +305,7 @@ public class ScheduleAnnouncementResponse {
    * Get targetChannelType
    * @return targetChannelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -331,7 +331,7 @@ public class ScheduleAnnouncementResponse {
    * Get createChannelOptions
    * @return createChannelOptions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -357,7 +357,7 @@ public class ScheduleAnnouncementResponse {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -383,7 +383,7 @@ public class ScheduleAnnouncementResponse {
    * Get scheduledAt
    * @return scheduledAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SCHEDULED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -409,7 +409,7 @@ public class ScheduleAnnouncementResponse {
    * Get ceaseAt
    * @return ceaseAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CEASE_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -435,7 +435,7 @@ public class ScheduleAnnouncementResponse {
    * Get resumeAt
    * @return resumeAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_RESUME_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -461,7 +461,7 @@ public class ScheduleAnnouncementResponse {
    * Get completedAt
    * @return completedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COMPLETED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -487,7 +487,7 @@ public class ScheduleAnnouncementResponse {
    * Get sentUserCount
    * @return sentUserCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENT_USER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -513,7 +513,7 @@ public class ScheduleAnnouncementResponse {
    * Get sentChannelCount
    * @return sentChannelCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENT_CHANNEL_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -539,7 +539,7 @@ public class ScheduleAnnouncementResponse {
    * Get openCount
    * @return openCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -565,7 +565,7 @@ public class ScheduleAnnouncementResponse {
    * Get openRate
    * @return openRate
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_RATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponseCreateChannelOptions.java
+++ b/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponseCreateChannelOptions.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ScheduleAnnouncementResponseCreateChannelOptions.JSON_PROPERTY_CUSTOM_TYPE
 })
 @JsonTypeName("scheduleAnnouncementResponse_create_channel_options")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ScheduleAnnouncementResponseCreateChannelOptions {
   public static final String JSON_PROPERTY_DISTINCT = "distinct";
   private Boolean distinct;
@@ -68,7 +68,7 @@ public class ScheduleAnnouncementResponseCreateChannelOptions {
    * Get distinct
    * @return distinct
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DISTINCT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class ScheduleAnnouncementResponseCreateChannelOptions {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -120,7 +120,7 @@ public class ScheduleAnnouncementResponseCreateChannelOptions {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -146,7 +146,7 @@ public class ScheduleAnnouncementResponseCreateChannelOptions {
    * Get coverUrl
    * @return coverUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -172,7 +172,7 @@ public class ScheduleAnnouncementResponseCreateChannelOptions {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponseMessage.java
+++ b/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponseMessage.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ScheduleAnnouncementResponseMessage.JSON_PROPERTY_DATA
 })
 @JsonTypeName("scheduleAnnouncementResponse_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ScheduleAnnouncementResponseMessage {
   public static final String JSON_PROPERTY_TYPE = "type";
   private String type;
@@ -68,7 +68,7 @@ public class ScheduleAnnouncementResponseMessage {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class ScheduleAnnouncementResponseMessage {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -120,7 +120,7 @@ public class ScheduleAnnouncementResponseMessage {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -146,7 +146,7 @@ public class ScheduleAnnouncementResponseMessage {
    * Get content
    * @return content
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CONTENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -172,7 +172,7 @@ public class ScheduleAnnouncementResponseMessage {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdAdminMessage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdAdminMessage.java
@@ -73,7 +73,7 @@ import org.sendbird.client.JSON;
   SendBirdAdminMessage.JSON_PROPERTY_UPDATED_AT
 })
 @JsonTypeName("SendBird.AdminMessage")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdAdminMessage {
   public static final String JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS = "apple_critical_alert_options";
   private SendBirdAppleCriticalAlertOptions appleCriticalAlertOptions;
@@ -237,7 +237,7 @@ public class SendBirdAdminMessage {
    * Get appleCriticalAlertOptions
    * @return appleCriticalAlertOptions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -263,7 +263,7 @@ public class SendBirdAdminMessage {
    * Get channelType
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -289,7 +289,7 @@ public class SendBirdAdminMessage {
    * Get channelUrl
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -315,7 +315,7 @@ public class SendBirdAdminMessage {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -341,7 +341,7 @@ public class SendBirdAdminMessage {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -367,7 +367,7 @@ public class SendBirdAdminMessage {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -393,7 +393,7 @@ public class SendBirdAdminMessage {
    * Get isReplyToChannel
    * @return isReplyToChannel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_REPLY_TO_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -419,7 +419,7 @@ public class SendBirdAdminMessage {
    * Get mentionType
    * @return mentionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -453,7 +453,7 @@ public class SendBirdAdminMessage {
    * Get mentionedUsers
    * @return mentionedUsers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -479,7 +479,7 @@ public class SendBirdAdminMessage {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -505,7 +505,7 @@ public class SendBirdAdminMessage {
    * Get messageId
    * @return messageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -531,7 +531,7 @@ public class SendBirdAdminMessage {
    * Get messageType
    * @return messageType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -557,7 +557,7 @@ public class SendBirdAdminMessage {
    * Get metaArray
    * @return metaArray
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_META_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -591,7 +591,7 @@ public class SendBirdAdminMessage {
    * Get metaArrays
    * @return metaArrays
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_META_ARRAYS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -617,7 +617,7 @@ public class SendBirdAdminMessage {
    * Get ogMetaData
    * @return ogMetaData
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OG_META_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -643,7 +643,7 @@ public class SendBirdAdminMessage {
    * Get parentMessage
    * @return parentMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -677,7 +677,7 @@ public class SendBirdAdminMessage {
    * Get parentMessageId
    * @return parentMessageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARENT_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -703,7 +703,7 @@ public class SendBirdAdminMessage {
    * Get parentMessageText
    * @return parentMessageText
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARENT_MESSAGE_TEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -737,7 +737,7 @@ public class SendBirdAdminMessage {
    * Get reactions
    * @return reactions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REACTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -763,7 +763,7 @@ public class SendBirdAdminMessage {
    * Get sendingStatus
    * @return sendingStatus
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENDING_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -789,7 +789,7 @@ public class SendBirdAdminMessage {
    * Get silent
    * @return silent
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SILENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -815,7 +815,7 @@ public class SendBirdAdminMessage {
    * Get threadInfo
    * @return threadInfo
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_THREAD_INFO)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -841,7 +841,7 @@ public class SendBirdAdminMessage {
    * Get translations
    * @return translations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TRANSLATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -867,7 +867,7 @@ public class SendBirdAdminMessage {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdAppleCriticalAlertOptions.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdAppleCriticalAlertOptions.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SendBirdAppleCriticalAlertOptions.JSON_PROPERTY_VOLUME
 })
 @JsonTypeName("SendBird.AppleCriticalAlertOptions")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdAppleCriticalAlertOptions {
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;
@@ -57,7 +57,7 @@ public class SendBirdAppleCriticalAlertOptions {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class SendBirdAppleCriticalAlertOptions {
    * Get volume
    * @return volume
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VOLUME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdAutoEventMessageSettings.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdAutoEventMessageSettings.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   SendBirdAutoEventMessageSettings.JSON_PROPERTY_AUTO_EVENT_MESSAGE
 })
 @JsonTypeName("SendBird.AutoEventMessageSettings")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdAutoEventMessageSettings {
   public static final String JSON_PROPERTY_AUTO_EVENT_MESSAGE = "auto_event_message";
   private ConfigureAutoEventDataAutoEventMessage autoEventMessage;
@@ -53,7 +53,7 @@ public class SendBirdAutoEventMessageSettings {
    * Get autoEventMessage
    * @return autoEventMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_AUTO_EVENT_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdBaseChannel.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBaseChannel.java
@@ -45,7 +45,7 @@ import org.sendbird.client.JSON;
   SendBirdBaseChannel.JSON_PROPERTY_URL
 })
 @JsonTypeName("SendBird.BaseChannel")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdBaseChannel {
   public static final String JSON_PROPERTY_COVER_URL = "cover_url";
   private String coverUrl;
@@ -86,7 +86,7 @@ public class SendBirdBaseChannel {
    * Get coverUrl
    * @return coverUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -112,7 +112,7 @@ public class SendBirdBaseChannel {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -138,7 +138,7 @@ public class SendBirdBaseChannel {
    * Get creator
    * @return creator
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -164,7 +164,7 @@ public class SendBirdBaseChannel {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -190,7 +190,7 @@ public class SendBirdBaseChannel {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -216,7 +216,7 @@ public class SendBirdBaseChannel {
    * Get isEphemeral
    * @return isEphemeral
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_EPHEMERAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -242,7 +242,7 @@ public class SendBirdBaseChannel {
    * Get isFrozen
    * @return isFrozen
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_FROZEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -268,7 +268,7 @@ public class SendBirdBaseChannel {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -294,7 +294,7 @@ public class SendBirdBaseChannel {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdBaseMessageInstance.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBaseMessageInstance.java
@@ -72,7 +72,7 @@ import org.sendbird.client.JSON;
   SendBirdBaseMessageInstance.JSON_PROPERTY_UPDATED_AT
 })
 @JsonTypeName("SendBird.BaseMessageInstance")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdBaseMessageInstance {
   public static final String JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS = "apple_critical_alert_options";
   private SendBirdAppleCriticalAlertOptions appleCriticalAlertOptions;
@@ -232,7 +232,7 @@ public class SendBirdBaseMessageInstance {
    * Get appleCriticalAlertOptions
    * @return appleCriticalAlertOptions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -258,7 +258,7 @@ public class SendBirdBaseMessageInstance {
    * Get channelType
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -284,7 +284,7 @@ public class SendBirdBaseMessageInstance {
    * Get channelUrl
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -310,7 +310,7 @@ public class SendBirdBaseMessageInstance {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -336,7 +336,7 @@ public class SendBirdBaseMessageInstance {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -362,7 +362,7 @@ public class SendBirdBaseMessageInstance {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -388,7 +388,7 @@ public class SendBirdBaseMessageInstance {
    * Get isReplyToChannel
    * @return isReplyToChannel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_REPLY_TO_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -414,7 +414,7 @@ public class SendBirdBaseMessageInstance {
    * Get mentionType
    * @return mentionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -448,7 +448,7 @@ public class SendBirdBaseMessageInstance {
    * Get mentionedUsers
    * @return mentionedUsers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -474,7 +474,7 @@ public class SendBirdBaseMessageInstance {
    * Get messageId
    * @return messageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -500,7 +500,7 @@ public class SendBirdBaseMessageInstance {
    * Get messageType
    * @return messageType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -526,7 +526,7 @@ public class SendBirdBaseMessageInstance {
    * Get metaArray
    * @return metaArray
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_META_ARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -560,7 +560,7 @@ public class SendBirdBaseMessageInstance {
    * Get metaArrays
    * @return metaArrays
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_META_ARRAYS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -586,7 +586,7 @@ public class SendBirdBaseMessageInstance {
    * Get ogMetaData
    * @return ogMetaData
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OG_META_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -612,7 +612,7 @@ public class SendBirdBaseMessageInstance {
    * Get parentMessage
    * @return parentMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -646,7 +646,7 @@ public class SendBirdBaseMessageInstance {
    * Get parentMessageId
    * @return parentMessageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARENT_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -672,7 +672,7 @@ public class SendBirdBaseMessageInstance {
    * Get parentMessageText
    * @return parentMessageText
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARENT_MESSAGE_TEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -706,7 +706,7 @@ public class SendBirdBaseMessageInstance {
    * Get reactions
    * @return reactions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REACTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -732,7 +732,7 @@ public class SendBirdBaseMessageInstance {
    * Get sendingStatus
    * @return sendingStatus
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENDING_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -758,7 +758,7 @@ public class SendBirdBaseMessageInstance {
    * Get silent
    * @return silent
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SILENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -784,7 +784,7 @@ public class SendBirdBaseMessageInstance {
    * Get threadInfo
    * @return threadInfo
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_THREAD_INFO)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -810,7 +810,7 @@ public class SendBirdBaseMessageInstance {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   SendBirdBotsMessageResponse.JSON_PROPERTY_MESSAGE
 })
 @JsonTypeName("SendBird.BotsMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdBotsMessageResponse {
   public static final String JSON_PROPERTY_MESSAGE = "message";
   private SendBirdBotsMessageResponseMessage message;
@@ -53,7 +53,7 @@ public class SendBirdBotsMessageResponse {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessage.java
@@ -62,7 +62,7 @@ import org.sendbird.client.JSON;
   SendBirdBotsMessageResponseMessage.JSON_PROPERTY_EXTENDED_MESSAGE_PAYLOAD
 })
 @JsonTypeName("SendBird_BotsMessageResponse_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdBotsMessageResponseMessage {
   public static final String JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS = "message_survival_seconds";
   private BigDecimal messageSurvivalSeconds;
@@ -139,7 +139,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get messageSurvivalSeconds
    * @return messageSurvivalSeconds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -165,7 +165,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -199,7 +199,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get mentionedUsers
    * @return mentionedUsers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -225,7 +225,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get translations
    * @return translations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TRANSLATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -251,7 +251,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -277,7 +277,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get isOpMsg
    * @return isOpMsg
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_OP_MSG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -303,7 +303,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get isRemoved
    * @return isRemoved
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_REMOVED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -329,7 +329,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -355,7 +355,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get _file
    * @return _file
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -381,7 +381,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -407,7 +407,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -433,7 +433,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get messageRetentionHour
    * @return messageRetentionHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_RETENTION_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -459,7 +459,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get silent
    * @return silent
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SILENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -485,7 +485,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -511,7 +511,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -537,7 +537,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get channelType
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -563,7 +563,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get mentionType
    * @return mentionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -589,7 +589,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get channelUrl
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -615,7 +615,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get messageId
    * @return messageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -641,7 +641,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get messageEvents
    * @return messageEvents
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_EVENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -667,7 +667,7 @@ public class SendBirdBotsMessageResponseMessage {
    * Get extendedMessagePayload
    * @return extendedMessagePayload
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EXTENDED_MESSAGE_PAYLOAD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessageExtendedMessagePayload.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessageExtendedMessagePayload.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdBotsMessageResponseMessageExtendedMessagePayload.JSON_PROPERTY_CUSTOM_VIEW
 })
 @JsonTypeName("SendBird_BotsMessageResponse_message_extended_message_payload")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdBotsMessageResponseMessageExtendedMessagePayload {
   public static final String JSON_PROPERTY_SUGGESTED_REPLIES = "suggested_replies";
   private List<String> suggestedReplies = null;
@@ -66,7 +66,7 @@ public class SendBirdBotsMessageResponseMessageExtendedMessagePayload {
    * Get suggestedReplies
    * @return suggestedReplies
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SUGGESTED_REPLIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class SendBirdBotsMessageResponseMessageExtendedMessagePayload {
    * Get customView
    * @return customView
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_VIEW)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessageMessageEvents.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessageMessageEvents.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdBotsMessageResponseMessageMessageEvents.JSON_PROPERTY_UPDATE_LAST_MESSAGE
 })
 @JsonTypeName("SendBird_BotsMessageResponse_message_message_events")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdBotsMessageResponseMessageMessageEvents {
   public static final String JSON_PROPERTY_SEND_PUSH_NOTIFICATION = "send_push_notification";
   private String sendPushNotification;
@@ -64,7 +64,7 @@ public class SendBirdBotsMessageResponseMessageMessageEvents {
    * Get sendPushNotification
    * @return sendPushNotification
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SEND_PUSH_NOTIFICATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -90,7 +90,7 @@ public class SendBirdBotsMessageResponseMessageMessageEvents {
    * Get updateUnreadCount
    * @return updateUnreadCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATE_UNREAD_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -116,7 +116,7 @@ public class SendBirdBotsMessageResponseMessageMessageEvents {
    * Get updateMentionCount
    * @return updateMentionCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATE_MENTION_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -142,7 +142,7 @@ public class SendBirdBotsMessageResponseMessageMessageEvents {
    * Get updateLastMessage
    * @return updateLastMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATE_LAST_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdChannelResponse.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdChannelResponse.java
@@ -44,8 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.sendbird.client.JSON;
 
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -67,7 +67,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.sendbird.client.JSON;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 @JsonDeserialize(using=SendBirdChannelResponse.SendBirdChannelResponseDeserializer.class)
 @JsonSerialize(using = SendBirdChannelResponse.SendBirdChannelResponseSerializer.class)
 public class SendBirdChannelResponse extends AbstractOpenApiSchema {

--- a/src/main/java/org/openapitools/client/model/SendBirdEmoji.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdEmoji.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   SendBirdEmoji.JSON_PROPERTY_URL
 })
 @JsonTypeName("SendBird.Emoji")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdEmoji {
   public static final String JSON_PROPERTY_KEY = "key";
   private String key;
@@ -56,7 +56,7 @@ public class SendBirdEmoji {
    * Get key
    * @return key
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -82,7 +82,7 @@ public class SendBirdEmoji {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdEmojiCategory.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdEmojiCategory.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   SendBirdEmojiCategory.JSON_PROPERTY_URL
 })
 @JsonTypeName("SendBird.EmojiCategory")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdEmojiCategory {
   public static final String JSON_PROPERTY_EMOJIS = "emojis";
   private List<SendBirdEmoji> emojis = null;
@@ -76,7 +76,7 @@ public class SendBirdEmojiCategory {
    * Get emojis
    * @return emojis
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EMOJIS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -102,7 +102,7 @@ public class SendBirdEmojiCategory {
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -128,7 +128,7 @@ public class SendBirdEmojiCategory {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -154,7 +154,7 @@ public class SendBirdEmojiCategory {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdFileMessageParams.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdFileMessageParams.java
@@ -59,7 +59,7 @@ import org.sendbird.client.JSON;
   SendBirdFileMessageParams.JSON_PROPERTY_THUMBNAIL_SIZES
 })
 @JsonTypeName("SendBird.FileMessageParams")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdFileMessageParams {
   public static final String JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS = "apple_critical_alert_options";
   private SendBirdAppleCriticalAlertOptions appleCriticalAlertOptions;
@@ -194,7 +194,7 @@ public class SendBirdFileMessageParams {
    * Get appleCriticalAlertOptions
    * @return appleCriticalAlertOptions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -220,7 +220,7 @@ public class SendBirdFileMessageParams {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -246,7 +246,7 @@ public class SendBirdFileMessageParams {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -272,7 +272,7 @@ public class SendBirdFileMessageParams {
    * Get _file
    * @return _file
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -298,7 +298,7 @@ public class SendBirdFileMessageParams {
    * Get fileName
    * @return fileName
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -324,7 +324,7 @@ public class SendBirdFileMessageParams {
    * Get fileSize
    * @return fileSize
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE_SIZE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -350,7 +350,7 @@ public class SendBirdFileMessageParams {
    * Get fileUrl
    * @return fileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -376,7 +376,7 @@ public class SendBirdFileMessageParams {
    * Get isReplyToChannel
    * @return isReplyToChannel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_REPLY_TO_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -402,7 +402,7 @@ public class SendBirdFileMessageParams {
    * Get mentionType
    * @return mentionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -436,7 +436,7 @@ public class SendBirdFileMessageParams {
    * Get mentionedUserIds
    * @return mentionedUserIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -470,7 +470,7 @@ public class SendBirdFileMessageParams {
    * Get mentionedUsers
    * @return mentionedUsers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -504,7 +504,7 @@ public class SendBirdFileMessageParams {
    * Get metaArrayKeys
    * @return metaArrayKeys
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_META_ARRAY_KEYS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -538,7 +538,7 @@ public class SendBirdFileMessageParams {
    * Get metaArrays
    * @return metaArrays
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_META_ARRAYS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -564,7 +564,7 @@ public class SendBirdFileMessageParams {
    * Get mimeType
    * @return mimeType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MIME_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -590,7 +590,7 @@ public class SendBirdFileMessageParams {
    * Get parentMessageId
    * @return parentMessageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARENT_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -616,7 +616,7 @@ public class SendBirdFileMessageParams {
    * Get pushNotificationDeliveryOption
    * @return pushNotificationDeliveryOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_NOTIFICATION_DELIVERY_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -650,7 +650,7 @@ public class SendBirdFileMessageParams {
    * Get thumbnailSizes
    * @return thumbnailSizes
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_THUMBNAIL_SIZES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannel.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannel.java
@@ -92,7 +92,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannel.JSON_PROPERTY_CHANNEL
 })
 @JsonTypeName("SendBird.GroupChannel")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdGroupChannel {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -423,7 +423,7 @@ public class SendBirdGroupChannel {
    * Get channelUrl
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -449,7 +449,7 @@ public class SendBirdGroupChannel {
    * Get coverUrl
    * @return coverUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -475,7 +475,7 @@ public class SendBirdGroupChannel {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -501,7 +501,7 @@ public class SendBirdGroupChannel {
    * Get createdBy
    * @return createdBy
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -535,7 +535,7 @@ public class SendBirdGroupChannel {
    * Get creator
    * @return creator
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -561,7 +561,7 @@ public class SendBirdGroupChannel {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -587,7 +587,7 @@ public class SendBirdGroupChannel {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -613,7 +613,7 @@ public class SendBirdGroupChannel {
    * Get disappearingMessage
    * @return disappearingMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DISAPPEARING_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -639,7 +639,7 @@ public class SendBirdGroupChannel {
    * Get freeze
    * @return freeze
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FREEZE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -665,7 +665,7 @@ public class SendBirdGroupChannel {
    * Get ignoreProfanityFilter
    * @return ignoreProfanityFilter
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IGNORE_PROFANITY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -691,7 +691,7 @@ public class SendBirdGroupChannel {
    * Get hiddenState
    * @return hiddenState
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_HIDDEN_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -717,7 +717,7 @@ public class SendBirdGroupChannel {
    * Get invitedAt
    * @return invitedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_INVITED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -743,7 +743,7 @@ public class SendBirdGroupChannel {
    * Get inviter
    * @return inviter
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_INVITER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -769,7 +769,7 @@ public class SendBirdGroupChannel {
    * Get isAccessCodeRequired
    * @return isAccessCodeRequired
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_ACCESS_CODE_REQUIRED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -795,7 +795,7 @@ public class SendBirdGroupChannel {
    * Get isBroadcast
    * @return isBroadcast
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_BROADCAST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -821,7 +821,7 @@ public class SendBirdGroupChannel {
    * Get isCreated
    * @return isCreated
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_CREATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -847,7 +847,7 @@ public class SendBirdGroupChannel {
    * Get isDiscoverable
    * @return isDiscoverable
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_DISCOVERABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -873,7 +873,7 @@ public class SendBirdGroupChannel {
    * Get isDistinct
    * @return isDistinct
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_DISTINCT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -899,7 +899,7 @@ public class SendBirdGroupChannel {
    * Get isEphemeral
    * @return isEphemeral
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_EPHEMERAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -925,7 +925,7 @@ public class SendBirdGroupChannel {
    * Get isFrozen
    * @return isFrozen
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_FROZEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -951,7 +951,7 @@ public class SendBirdGroupChannel {
    * Get isHidden
    * @return isHidden
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_HIDDEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -977,7 +977,7 @@ public class SendBirdGroupChannel {
    * Get isPublic
    * @return isPublic
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_PUBLIC)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1003,7 +1003,7 @@ public class SendBirdGroupChannel {
    * Get isPushEnabled
    * @return isPushEnabled
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_PUSH_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1029,7 +1029,7 @@ public class SendBirdGroupChannel {
    * Get isSuper
    * @return isSuper
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_SUPER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1055,7 +1055,7 @@ public class SendBirdGroupChannel {
    * Get joinedAt
    * @return joinedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_JOINED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1081,7 +1081,7 @@ public class SendBirdGroupChannel {
    * Get joinedMemberCount
    * @return joinedMemberCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_JOINED_MEMBER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1107,7 +1107,7 @@ public class SendBirdGroupChannel {
    * Get lastMessage
    * @return lastMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -1141,7 +1141,7 @@ public class SendBirdGroupChannel {
    * Get maxLengthMessage
    * @return maxLengthMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAX_LENGTH_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1167,7 +1167,7 @@ public class SendBirdGroupChannel {
    * Get memberCount
    * @return memberCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MEMBER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1201,7 +1201,7 @@ public class SendBirdGroupChannel {
    * Get members
    * @return members
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MEMBERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1227,7 +1227,7 @@ public class SendBirdGroupChannel {
    * Get messageOffsetTimestamp
    * @return messageOffsetTimestamp
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_OFFSET_TIMESTAMP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1253,7 +1253,7 @@ public class SendBirdGroupChannel {
    * Get messageSurvivalSeconds
    * @return messageSurvivalSeconds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1279,7 +1279,7 @@ public class SendBirdGroupChannel {
    * Get myCountPreference
    * @return myCountPreference
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MY_COUNT_PREFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1305,7 +1305,7 @@ public class SendBirdGroupChannel {
    * Get myLastRead
    * @return myLastRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MY_LAST_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1331,7 +1331,7 @@ public class SendBirdGroupChannel {
    * Get myMemberState
    * @return myMemberState
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MY_MEMBER_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1357,7 +1357,7 @@ public class SendBirdGroupChannel {
    * Get myMutedState
    * @return myMutedState
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MY_MUTED_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1383,7 +1383,7 @@ public class SendBirdGroupChannel {
    * Get myPushTriggerOption
    * @return myPushTriggerOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MY_PUSH_TRIGGER_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1409,7 +1409,7 @@ public class SendBirdGroupChannel {
    * Get myRole
    * @return myRole
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MY_ROLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1435,7 +1435,7 @@ public class SendBirdGroupChannel {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1469,7 +1469,7 @@ public class SendBirdGroupChannel {
    * Get operators
    * @return operators
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPERATORS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1495,7 +1495,7 @@ public class SendBirdGroupChannel {
    * Get smsFallback
    * @return smsFallback
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SMS_FALLBACK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1521,7 +1521,7 @@ public class SendBirdGroupChannel {
    * Get unreadMentionCount
    * @return unreadMentionCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNREAD_MENTION_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1547,7 +1547,7 @@ public class SendBirdGroupChannel {
    * Get unreadMessageCount
    * @return unreadMessageCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNREAD_MESSAGE_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -1573,7 +1573,7 @@ public class SendBirdGroupChannel {
    * Get channel
    * @return channel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelChannel.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelChannel.java
@@ -43,7 +43,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannelChannel.JSON_PROPERTY_MEMBER_COUNT
 })
 @JsonTypeName("SendBird_GroupChannel_channel")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdGroupChannelChannel {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -81,7 +81,7 @@ public class SendBirdGroupChannelChannel {
    * Get channelUrl
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -107,7 +107,7 @@ public class SendBirdGroupChannelChannel {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -133,7 +133,7 @@ public class SendBirdGroupChannelChannel {
    * Get coverUrl
    * @return coverUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -159,7 +159,7 @@ public class SendBirdGroupChannelChannel {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -185,7 +185,7 @@ public class SendBirdGroupChannelChannel {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -211,7 +211,7 @@ public class SendBirdGroupChannelChannel {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -237,7 +237,7 @@ public class SendBirdGroupChannelChannel {
    * Get maxLengthMessage
    * @return maxLengthMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAX_LENGTH_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -263,7 +263,7 @@ public class SendBirdGroupChannelChannel {
    * Get memberCount
    * @return memberCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MEMBER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelCollection.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelCollection.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannelCollection.JSON_PROPERTY_HAS_MORE
 })
 @JsonTypeName("SendBird.GroupChannelCollection")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdGroupChannelCollection {
   public static final String JSON_PROPERTY_CHANNEL_LIST = "channel_list";
   private List<SendBirdGroupChannel> channelList = null;
@@ -67,7 +67,7 @@ public class SendBirdGroupChannelCollection {
    * Get channelList
    * @return channelList
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_LIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class SendBirdGroupChannelCollection {
    * Get hasMore
    * @return hasMore
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_HAS_MORE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelCreatedBy.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelCreatedBy.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannelCreatedBy.JSON_PROPERTY_PROFILE_URL
 })
 @JsonTypeName("SendBird_GroupChannel_created_by")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdGroupChannelCreatedBy {
   public static final String JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE = "require_auth_for_profile_image";
   private Boolean requireAuthForProfileImage;
@@ -64,7 +64,7 @@ public class SendBirdGroupChannelCreatedBy {
    * Get requireAuthForProfileImage
    * @return requireAuthForProfileImage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -90,7 +90,7 @@ public class SendBirdGroupChannelCreatedBy {
    * Get nickname
    * @return nickname
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -116,7 +116,7 @@ public class SendBirdGroupChannelCreatedBy {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -142,7 +142,7 @@ public class SendBirdGroupChannelCreatedBy {
    * Get profileUrl
    * @return profileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelDisappearingMessage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelDisappearingMessage.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannelDisappearingMessage.JSON_PROPERTY_IS_TRIGGERED_BY_MESSAGE_READ
 })
 @JsonTypeName("SendBird_GroupChannel_disappearing_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdGroupChannelDisappearingMessage {
   public static final String JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS = "message_survival_seconds";
   private BigDecimal messageSurvivalSeconds;
@@ -57,7 +57,7 @@ public class SendBirdGroupChannelDisappearingMessage {
    * Get messageSurvivalSeconds
    * @return messageSurvivalSeconds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class SendBirdGroupChannelDisappearingMessage {
    * Get isTriggeredByMessageRead
    * @return isTriggeredByMessageRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_TRIGGERED_BY_MESSAGE_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelInviter.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelInviter.java
@@ -32,8 +32,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.sendbird.client.JSON;
 
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -55,7 +55,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.sendbird.client.JSON;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2022-11-07T15:23:06.856887Z[Europe/London]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2022-11-07T15:23:06.856887Z[Europe/London]")
 @JsonDeserialize(using=SendBirdGroupChannelInviter.SendBirdGroupChannelInviterDeserializer.class)
 @JsonSerialize(using = SendBirdGroupChannelInviter.SendBirdGroupChannelInviterSerializer.class)
 public class SendBirdGroupChannelInviter extends AbstractOpenApiSchema {

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelLastMessage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelLastMessage.java
@@ -34,8 +34,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.sendbird.client.JSON;
 
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -57,7 +57,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.sendbird.client.JSON;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2022-11-07T15:23:06.856887Z[Europe/London]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2022-11-07T15:23:06.856887Z[Europe/London]")
 @JsonDeserialize(using=SendBirdGroupChannelLastMessage.SendBirdGroupChannelLastMessageDeserializer.class)
 @JsonSerialize(using = SendBirdGroupChannelLastMessage.SendBirdGroupChannelLastMessageSerializer.class)
 public class SendBirdGroupChannelLastMessage extends AbstractOpenApiSchema {

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelSmsFallback.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelSmsFallback.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannelSmsFallback.JSON_PROPERTY_EXCLUDE_USER_IDS
 })
 @JsonTypeName("SendBird_GroupChannel_sms_fallback")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdGroupChannelSmsFallback {
   public static final String JSON_PROPERTY_WAIT_SECONDS = "wait_seconds";
   private BigDecimal waitSeconds;
@@ -59,7 +59,7 @@ public class SendBirdGroupChannelSmsFallback {
    * Get waitSeconds
    * @return waitSeconds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_WAIT_SECONDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class SendBirdGroupChannelSmsFallback {
    * Get excludeUserIds
    * @return excludeUserIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EXCLUDE_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdMember.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdMember.java
@@ -62,7 +62,7 @@ import org.sendbird.client.JSON;
   SendBirdMember.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("SendBird.Member")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdMember {
   public static final String JSON_PROPERTY_CONNECTION_STATUS = "connection_status";
   private String connectionStatus;
@@ -210,7 +210,7 @@ public class SendBirdMember {
    * Get connectionStatus
    * @return connectionStatus
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CONNECTION_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -236,7 +236,7 @@ public class SendBirdMember {
    * Get friendDiscoveryKey
    * @return friendDiscoveryKey
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -270,7 +270,7 @@ public class SendBirdMember {
    * Get friendName
    * @return friendName
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -304,7 +304,7 @@ public class SendBirdMember {
    * Get isActive
    * @return isActive
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -330,7 +330,7 @@ public class SendBirdMember {
    * Get isMuted
    * @return isMuted
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_MUTED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -356,7 +356,7 @@ public class SendBirdMember {
    * Get lastSeenAt
    * @return lastSeenAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_LAST_SEEN_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -382,7 +382,7 @@ public class SendBirdMember {
    * Get nickname
    * @return nickname
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -408,7 +408,7 @@ public class SendBirdMember {
    * Get plainProfileUrl
    * @return plainProfileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PLAIN_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -442,7 +442,7 @@ public class SendBirdMember {
    * Get preferredLanguages
    * @return preferredLanguages
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PREFERRED_LANGUAGES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -468,7 +468,7 @@ public class SendBirdMember {
    * Get profileUrl
    * @return profileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -494,7 +494,7 @@ public class SendBirdMember {
    * Get requireAuth
    * @return requireAuth
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUIRE_AUTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -520,7 +520,7 @@ public class SendBirdMember {
    * Get requireAuthForProfileImage
    * @return requireAuthForProfileImage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -546,7 +546,7 @@ public class SendBirdMember {
    * Get metadata
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -572,7 +572,7 @@ public class SendBirdMember {
    * Get isOnline
    * @return isOnline
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_ONLINE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -598,7 +598,7 @@ public class SendBirdMember {
    * Get mutedEndAt
    * @return mutedEndAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MUTED_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -624,7 +624,7 @@ public class SendBirdMember {
    * Get mutedDescription
    * @return mutedDescription
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MUTED_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -650,7 +650,7 @@ public class SendBirdMember {
    * Get restrictionInfo
    * @return restrictionInfo
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_RESTRICTION_INFO)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -676,7 +676,7 @@ public class SendBirdMember {
    * Get role
    * @return role
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -710,7 +710,7 @@ public class SendBirdMember {
    * Get state
    * @return state
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonIgnore
 
@@ -744,7 +744,7 @@ public class SendBirdMember {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdMessageMetaArray.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdMessageMetaArray.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdMessageMetaArray.JSON_PROPERTY_VALUE
 })
 @JsonTypeName("SendBird.MessageMetaArray")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdMessageMetaArray {
   public static final String JSON_PROPERTY_KEY = "key";
   private String key;
@@ -58,7 +58,7 @@ public class SendBirdMessageMetaArray {
    * Get key
    * @return key
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class SendBirdMessageMetaArray {
    * Get value
    * @return value
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VALUE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdMessageResponse.java
@@ -66,7 +66,7 @@ import org.sendbird.client.JSON;
   SendBirdMessageResponse.JSON_PROPERTY_IS_REPLY_TO_CHANNEL
 })
 @JsonTypeName("SendBird.MessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdMessageResponse {
   public static final String JSON_PROPERTY_REQUIRE_AUTH = "require_auth";
   private Boolean requireAuth;
@@ -161,7 +161,7 @@ public class SendBirdMessageResponse {
    * Get requireAuth
    * @return requireAuth
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUIRE_AUTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -187,7 +187,7 @@ public class SendBirdMessageResponse {
    * Get messageSurvivalSeconds
    * @return messageSurvivalSeconds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -213,7 +213,7 @@ public class SendBirdMessageResponse {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -247,7 +247,7 @@ public class SendBirdMessageResponse {
    * Get mentionedUsers
    * @return mentionedUsers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -273,7 +273,7 @@ public class SendBirdMessageResponse {
    * Get translations
    * @return translations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TRANSLATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -299,7 +299,7 @@ public class SendBirdMessageResponse {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -325,7 +325,7 @@ public class SendBirdMessageResponse {
    * Get isOpMsg
    * @return isOpMsg
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_OP_MSG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -351,7 +351,7 @@ public class SendBirdMessageResponse {
    * Get isRemoved
    * @return isRemoved
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_REMOVED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -377,7 +377,7 @@ public class SendBirdMessageResponse {
    * Get user
    * @return user
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -403,7 +403,7 @@ public class SendBirdMessageResponse {
    * Get _file
    * @return _file
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -429,7 +429,7 @@ public class SendBirdMessageResponse {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -455,7 +455,7 @@ public class SendBirdMessageResponse {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -481,7 +481,7 @@ public class SendBirdMessageResponse {
    * Get messageRetentionHour
    * @return messageRetentionHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_RETENTION_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -507,7 +507,7 @@ public class SendBirdMessageResponse {
    * Get silent
    * @return silent
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SILENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -533,7 +533,7 @@ public class SendBirdMessageResponse {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -559,7 +559,7 @@ public class SendBirdMessageResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -585,7 +585,7 @@ public class SendBirdMessageResponse {
    * Get channelType
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -611,7 +611,7 @@ public class SendBirdMessageResponse {
    * Get reqId
    * @return reqId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQ_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -637,7 +637,7 @@ public class SendBirdMessageResponse {
    * Get mentionType
    * @return mentionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -663,7 +663,7 @@ public class SendBirdMessageResponse {
    * Get channelUrl
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -689,7 +689,7 @@ public class SendBirdMessageResponse {
    * Get messageId
    * @return messageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -715,7 +715,7 @@ public class SendBirdMessageResponse {
    * Get size
    * @return size
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SIZE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -749,7 +749,7 @@ public class SendBirdMessageResponse {
    * Get sortedMetaarray
    * @return sortedMetaarray
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SORTED_METAARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -775,7 +775,7 @@ public class SendBirdMessageResponse {
    * Get threadInfo
    * @return threadInfo
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_THREAD_INFO)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -801,7 +801,7 @@ public class SendBirdMessageResponse {
    * Get parentMessageId
    * @return parentMessageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARENT_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -827,7 +827,7 @@ public class SendBirdMessageResponse {
    * Get parentMessageInfo
    * @return parentMessageInfo
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARENT_MESSAGE_INFO)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -853,7 +853,7 @@ public class SendBirdMessageResponse {
    * Get isReplyToChannel
    * @return isReplyToChannel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_REPLY_TO_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdMessageResponseMentionedUsersInner.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdMessageResponseMentionedUsersInner.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBirdMessageResponseMentionedUsersInner.JSON_PROPERTY_METADATA
 })
 @JsonTypeName("SendBird_MessageResponse_mentioned_users_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdMessageResponseMentionedUsersInner {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -65,7 +65,7 @@ public class SendBirdMessageResponseMentionedUsersInner {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -91,7 +91,7 @@ public class SendBirdMessageResponseMentionedUsersInner {
    * Get nickname
    * @return nickname
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -117,7 +117,7 @@ public class SendBirdMessageResponseMentionedUsersInner {
    * Get profileUrl
    * @return profileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -143,7 +143,7 @@ public class SendBirdMessageResponseMentionedUsersInner {
    * Get metadata
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdMessageResponseUser.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdMessageResponseUser.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   SendBirdMessageResponseUser.JSON_PROPERTY_METADATA
 })
 @JsonTypeName("SendBird_MessageResponse_user")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdMessageResponseUser {
   public static final String JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE = "require_auth_for_profile_image";
   private Boolean requireAuthForProfileImage;
@@ -77,7 +77,7 @@ public class SendBirdMessageResponseUser {
    * Get requireAuthForProfileImage
    * @return requireAuthForProfileImage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -103,7 +103,7 @@ public class SendBirdMessageResponseUser {
    * Get isActive
    * @return isActive
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -129,7 +129,7 @@ public class SendBirdMessageResponseUser {
    * Get role
    * @return role
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ROLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -155,7 +155,7 @@ public class SendBirdMessageResponseUser {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -181,7 +181,7 @@ public class SendBirdMessageResponseUser {
    * Get nickname
    * @return nickname
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -207,7 +207,7 @@ public class SendBirdMessageResponseUser {
    * Get profileUrl
    * @return profileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -233,7 +233,7 @@ public class SendBirdMessageResponseUser {
    * Get metadata
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdOGImage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdOGImage.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   SendBirdOGImage.JSON_PROPERTY_WIDTH
 })
 @JsonTypeName("SendBird.OGImage")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdOGImage {
   public static final String JSON_PROPERTY_ALT = "alt";
   private String alt;
@@ -73,7 +73,7 @@ public class SendBirdOGImage {
    * Get alt
    * @return alt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ALT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -99,7 +99,7 @@ public class SendBirdOGImage {
    * Get height
    * @return height
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_HEIGHT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -125,7 +125,7 @@ public class SendBirdOGImage {
    * Get secureUrl
    * @return secureUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SECURE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -151,7 +151,7 @@ public class SendBirdOGImage {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -177,7 +177,7 @@ public class SendBirdOGImage {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -203,7 +203,7 @@ public class SendBirdOGImage {
    * Get width
    * @return width
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_WIDTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdOGMetaData.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdOGMetaData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBirdOGMetaData.JSON_PROPERTY_URL
 })
 @JsonTypeName("SendBird.OGMetaData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdOGMetaData {
   public static final String JSON_PROPERTY_DEFAULT_IMAGE = "default_image";
   private SendBirdOGImage defaultImage;
@@ -65,7 +65,7 @@ public class SendBirdOGMetaData {
    * Get defaultImage
    * @return defaultImage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DEFAULT_IMAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -91,7 +91,7 @@ public class SendBirdOGMetaData {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -117,7 +117,7 @@ public class SendBirdOGMetaData {
    * Get title
    * @return title
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -143,7 +143,7 @@ public class SendBirdOGMetaData {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdOpenChannel.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdOpenChannel.java
@@ -52,7 +52,7 @@ import org.sendbird.client.JSON;
   SendBirdOpenChannel.JSON_PROPERTY_FREEZE
 })
 @JsonTypeName("SendBird.OpenChannel")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdOpenChannel {
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;
@@ -108,7 +108,7 @@ public class SendBirdOpenChannel {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -134,7 +134,7 @@ public class SendBirdOpenChannel {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -160,7 +160,7 @@ public class SendBirdOpenChannel {
    * Get channelUrl
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -186,7 +186,7 @@ public class SendBirdOpenChannel {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -212,7 +212,7 @@ public class SendBirdOpenChannel {
    * Get coverUrl
    * @return coverUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -238,7 +238,7 @@ public class SendBirdOpenChannel {
    * Get creator
    * @return creator
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -264,7 +264,7 @@ public class SendBirdOpenChannel {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -290,7 +290,7 @@ public class SendBirdOpenChannel {
    * Get isDynamicPartitioned
    * @return isDynamicPartitioned
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_DYNAMIC_PARTITIONED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -316,7 +316,7 @@ public class SendBirdOpenChannel {
    * Get isEphemeral
    * @return isEphemeral
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_EPHEMERAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -342,7 +342,7 @@ public class SendBirdOpenChannel {
    * Get isFrozen
    * @return isFrozen
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_FROZEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -368,7 +368,7 @@ public class SendBirdOpenChannel {
    * Get maxLengthMessage
    * @return maxLengthMessage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAX_LENGTH_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -402,7 +402,7 @@ public class SendBirdOpenChannel {
    * Get operators
    * @return operators
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPERATORS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -428,7 +428,7 @@ public class SendBirdOpenChannel {
    * Get participantCount
    * @return participantCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARTICIPANT_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -454,7 +454,7 @@ public class SendBirdOpenChannel {
    * Get freeze
    * @return freeze
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FREEZE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdPlugin.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdPlugin.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SendBirdPlugin.JSON_PROPERTY_VENDOR
 })
 @JsonTypeName("SendBird.Plugin")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdPlugin {
   public static final String JSON_PROPERTY_DETAIL = "detail";
   private Object detail;
@@ -60,7 +60,7 @@ public class SendBirdPlugin {
    * Get detail
    * @return detail
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DETAIL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -86,7 +86,7 @@ public class SendBirdPlugin {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -112,7 +112,7 @@ public class SendBirdPlugin {
    * Get vendor
    * @return vendor
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VENDOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdPoll.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdPoll.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBirdPoll.JSON_PROPERTY_TITLE
 })
 @JsonTypeName("SendBird.Poll")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdPoll {
   public static final String JSON_PROPERTY_DETAILS = "details";
   private SendBirdPollDetails details;
@@ -62,7 +62,7 @@ public class SendBirdPoll {
    * Get details
    * @return details
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DETAILS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -88,7 +88,7 @@ public class SendBirdPoll {
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -114,7 +114,7 @@ public class SendBirdPoll {
    * Get title
    * @return title
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdPollDetails.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdPollDetails.java
@@ -48,7 +48,7 @@ import org.sendbird.client.JSON;
   SendBirdPollDetails.JSON_PROPERTY_VOTER_COUNT
 })
 @JsonTypeName("SendBird.PollDetails")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdPollDetails {
   public static final String JSON_PROPERTY_ALLOW_MULTIPLE_VOTES = "allow_multiple_votes";
   private Boolean allowMultipleVotes;
@@ -129,7 +129,7 @@ public class SendBirdPollDetails {
    * Get allowMultipleVotes
    * @return allowMultipleVotes
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ALLOW_MULTIPLE_VOTES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -155,7 +155,7 @@ public class SendBirdPollDetails {
    * Get allowUserSuggestion
    * @return allowUserSuggestion
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ALLOW_USER_SUGGESTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -181,7 +181,7 @@ public class SendBirdPollDetails {
    * Get closeAt
    * @return closeAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CLOSE_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -207,7 +207,7 @@ public class SendBirdPollDetails {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -233,7 +233,7 @@ public class SendBirdPollDetails {
    * Get createdBy
    * @return createdBy
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_BY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -259,7 +259,7 @@ public class SendBirdPollDetails {
    * Get isAnonymous
    * @return isAnonymous
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_ANONYMOUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -293,7 +293,7 @@ public class SendBirdPollDetails {
    * Get options
    * @return options
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -319,7 +319,7 @@ public class SendBirdPollDetails {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -345,7 +345,7 @@ public class SendBirdPollDetails {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -371,7 +371,7 @@ public class SendBirdPollDetails {
    * Get voterCount
    * @return voterCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VOTER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdPollOption.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdPollOption.java
@@ -46,7 +46,7 @@ import org.sendbird.client.JSON;
   SendBirdPollOption.JSON_PROPERTY_VOTE_COUNT
 })
 @JsonTypeName("SendBird.PollOption")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdPollOption {
   public static final String JSON_PROPERTY_CREATED_AT = "created_at";
   private BigDecimal createdAt;
@@ -84,7 +84,7 @@ public class SendBirdPollOption {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -110,7 +110,7 @@ public class SendBirdPollOption {
    * Get createdBy
    * @return createdBy
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_BY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -136,7 +136,7 @@ public class SendBirdPollOption {
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -170,7 +170,7 @@ public class SendBirdPollOption {
    * Get partialVoters
    * @return partialVoters
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARTIAL_VOTERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -196,7 +196,7 @@ public class SendBirdPollOption {
    * Get pollId
    * @return pollId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_POLL_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -222,7 +222,7 @@ public class SendBirdPollOption {
    * Get text
    * @return text
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -248,7 +248,7 @@ public class SendBirdPollOption {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -274,7 +274,7 @@ public class SendBirdPollOption {
    * Get voteCount
    * @return voteCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VOTE_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdPollUpdatedVoteCount.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdPollUpdatedVoteCount.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SendBirdPollUpdatedVoteCount.JSON_PROPERTY_VOTE_COUNT
 })
 @JsonTypeName("SendBird.PollUpdatedVoteCount")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdPollUpdatedVoteCount {
   public static final String JSON_PROPERTY_OPTION_ID = "option_id";
   private BigDecimal optionId;
@@ -57,7 +57,7 @@ public class SendBirdPollUpdatedVoteCount {
    * Get optionId
    * @return optionId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPTION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class SendBirdPollUpdatedVoteCount {
    * Get voteCount
    * @return voteCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VOTE_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdReaction.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdReaction.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   SendBirdReaction.JSON_PROPERTY_USER_IDS
 })
 @JsonTypeName("SendBird.Reaction")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdReaction {
   public static final String JSON_PROPERTY_KEY = "key";
   private String key;
@@ -63,7 +63,7 @@ public class SendBirdReaction {
    * Get key
    * @return key
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -89,7 +89,7 @@ public class SendBirdReaction {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -123,7 +123,7 @@ public class SendBirdReaction {
    * Get userIds
    * @return userIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdRestrictionInfo.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdRestrictionInfo.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdRestrictionInfo.JSON_PROPERTY_RESTRICTION_TYPE
 })
 @JsonTypeName("SendBird.RestrictionInfo")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdRestrictionInfo {
   public static final String JSON_PROPERTY_DESCRIPTION = "description";
   private String description;
@@ -96,7 +96,7 @@ public class SendBirdRestrictionInfo {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -122,7 +122,7 @@ public class SendBirdRestrictionInfo {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -148,7 +148,7 @@ public class SendBirdRestrictionInfo {
    * Get restrictionType
    * @return restrictionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_RESTRICTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdScheduledMessage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdScheduledMessage.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdScheduledMessage.JSON_PROPERTY_MESSAGE
 })
 @JsonTypeName("SendBird.ScheduledMessage")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdScheduledMessage {
   public static final String JSON_PROPERTY_SCHEDULED_MESSAGE_ID = "scheduled_message_id";
   private BigDecimal scheduledMessageId;
@@ -61,7 +61,7 @@ public class SendBirdScheduledMessage {
    * Get scheduledMessageId
    * @return scheduledMessageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SCHEDULED_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -87,7 +87,7 @@ public class SendBirdScheduledMessage {
    * Get messageType
    * @return messageType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -113,7 +113,7 @@ public class SendBirdScheduledMessage {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdSender.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdSender.java
@@ -49,7 +49,7 @@ import org.sendbird.client.JSON;
   SendBirdSender.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("SendBird.Sender")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdSender {
   public static final String JSON_PROPERTY_CONNECTION_STATUS = "connection_status";
   private String connectionStatus;
@@ -102,7 +102,7 @@ public class SendBirdSender {
    * Get connectionStatus
    * @return connectionStatus
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CONNECTION_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -128,7 +128,7 @@ public class SendBirdSender {
    * Get friendDiscoveryKey
    * @return friendDiscoveryKey
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FRIEND_DISCOVERY_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -154,7 +154,7 @@ public class SendBirdSender {
    * Get friendName
    * @return friendName
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FRIEND_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -180,7 +180,7 @@ public class SendBirdSender {
    * Get isActive
    * @return isActive
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -206,7 +206,7 @@ public class SendBirdSender {
    * Get isBlockedByMe
    * @return isBlockedByMe
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_BLOCKED_BY_ME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -232,7 +232,7 @@ public class SendBirdSender {
    * Get lastSeenAt
    * @return lastSeenAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_LAST_SEEN_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -258,7 +258,7 @@ public class SendBirdSender {
    * Get metadata
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -284,7 +284,7 @@ public class SendBirdSender {
    * Get nickname
    * @return nickname
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -310,7 +310,7 @@ public class SendBirdSender {
    * Get plainProfileUrl
    * @return plainProfileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PLAIN_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -344,7 +344,7 @@ public class SendBirdSender {
    * Get preferredLanguages
    * @return preferredLanguages
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PREFERRED_LANGUAGES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -370,7 +370,7 @@ public class SendBirdSender {
    * Get profileUrl
    * @return profileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -396,7 +396,7 @@ public class SendBirdSender {
    * Get requireAuth
    * @return requireAuth
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUIRE_AUTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -422,7 +422,7 @@ public class SendBirdSender {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdThreadInfo.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdThreadInfo.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   SendBirdThreadInfo.JSON_PROPERTY_UPDATED_AT
 })
 @JsonTypeName("SendBird.ThreadInfo")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdThreadInfo {
   public static final String JSON_PROPERTY_LAST_REPLIED_AT = "last_replied_at";
   private BigDecimal lastRepliedAt;
@@ -68,7 +68,7 @@ public class SendBirdThreadInfo {
    * Get lastRepliedAt
    * @return lastRepliedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_LAST_REPLIED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -102,7 +102,7 @@ public class SendBirdThreadInfo {
    * Get mostRepliedUsers
    * @return mostRepliedUsers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MOST_REPLIED_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -128,7 +128,7 @@ public class SendBirdThreadInfo {
    * Get replyCount
    * @return replyCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REPLY_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -154,7 +154,7 @@ public class SendBirdThreadInfo {
    * Get updatedAt
    * @return updatedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdThumbnailSBObject.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdThumbnailSBObject.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   SendBirdThumbnailSBObject.JSON_PROPERTY_WIDTH
 })
 @JsonTypeName("SendBird.ThumbnailSBObject")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdThumbnailSBObject {
   public static final String JSON_PROPERTY_HEIGHT = "height";
   private BigDecimal height;
@@ -73,7 +73,7 @@ public class SendBirdThumbnailSBObject {
    * Get height
    * @return height
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_HEIGHT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -99,7 +99,7 @@ public class SendBirdThumbnailSBObject {
    * Get plainUrl
    * @return plainUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PLAIN_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -125,7 +125,7 @@ public class SendBirdThumbnailSBObject {
    * Get realHeight
    * @return realHeight
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REAL_HEIGHT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -151,7 +151,7 @@ public class SendBirdThumbnailSBObject {
    * Get realWidth
    * @return realWidth
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REAL_WIDTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -177,7 +177,7 @@ public class SendBirdThumbnailSBObject {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -203,7 +203,7 @@ public class SendBirdThumbnailSBObject {
    * Get width
    * @return width
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_WIDTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdThumbnailSize.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdThumbnailSize.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SendBirdThumbnailSize.JSON_PROPERTY_MAX_WIDTH
 })
 @JsonTypeName("SendBird.ThumbnailSize")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdThumbnailSize {
   public static final String JSON_PROPERTY_MAX_HEIGHT = "max_height";
   private BigDecimal maxHeight;
@@ -57,7 +57,7 @@ public class SendBirdThumbnailSize {
    * Get maxHeight
    * @return maxHeight
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAX_HEIGHT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class SendBirdThumbnailSize {
    * Get maxWidth
    * @return maxWidth
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAX_WIDTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdUser.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdUser.java
@@ -61,7 +61,7 @@ import org.sendbird.client.JSON;
   SendBirdUser.JSON_PROPERTY_START_AT
 })
 @JsonTypeName("SendBird.User")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdUser {
   public static final String JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE = "require_auth_for_profile_image";
   private Boolean requireAuthForProfileImage;
@@ -144,7 +144,7 @@ public class SendBirdUser {
    * Get requireAuthForProfileImage
    * @return requireAuthForProfileImage
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -170,7 +170,7 @@ public class SendBirdUser {
    * Get isOnline
    * @return isOnline
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_ONLINE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -196,7 +196,7 @@ public class SendBirdUser {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -222,7 +222,7 @@ public class SendBirdUser {
    * Get accessToken
    * @return accessToken
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ACCESS_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -248,7 +248,7 @@ public class SendBirdUser {
    * Get hasEverLoggedIn
    * @return hasEverLoggedIn
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_HAS_EVER_LOGGED_IN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -274,7 +274,7 @@ public class SendBirdUser {
    * Get isActive
    * @return isActive
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -300,7 +300,7 @@ public class SendBirdUser {
    * Get lastSeenAt
    * @return lastSeenAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_LAST_SEEN_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -326,7 +326,7 @@ public class SendBirdUser {
    * Get nickname
    * @return nickname
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -360,7 +360,7 @@ public class SendBirdUser {
    * Get discoveryKeys
    * @return discoveryKeys
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DISCOVERY_KEYS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -394,7 +394,7 @@ public class SendBirdUser {
    * Get sessionTokens
    * @return sessionTokens
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SESSION_TOKENS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -428,7 +428,7 @@ public class SendBirdUser {
    * Get preferredLanguages
    * @return preferredLanguages
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PREFERRED_LANGUAGES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -454,7 +454,7 @@ public class SendBirdUser {
    * Get profileUrl
    * @return profileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -480,7 +480,7 @@ public class SendBirdUser {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -506,7 +506,7 @@ public class SendBirdUser {
    * Get phoneNumber
    * @return phoneNumber
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PHONE_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -532,7 +532,7 @@ public class SendBirdUser {
    * Get local
    * @return local
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_LOCAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -558,7 +558,7 @@ public class SendBirdUser {
    * Get locale
    * @return locale
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_LOCALE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -584,7 +584,7 @@ public class SendBirdUser {
    * Get isHideMeFromFriends
    * @return isHideMeFromFriends
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_HIDE_ME_FROM_FRIENDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -610,7 +610,7 @@ public class SendBirdUser {
    * Get isShadowBlocked
    * @return isShadowBlocked
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_SHADOW_BLOCKED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -636,7 +636,7 @@ public class SendBirdUser {
    * Get isCreated
    * @return isCreated
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_CREATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -662,7 +662,7 @@ public class SendBirdUser {
    * Get metadata
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -688,7 +688,7 @@ public class SendBirdUser {
    * Get description
    * @return description
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -714,7 +714,7 @@ public class SendBirdUser {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -740,7 +740,7 @@ public class SendBirdUser {
    * Get startAt
    * @return startAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBirdUserMessageParams.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdUserMessageParams.java
@@ -55,7 +55,7 @@ import org.sendbird.client.JSON;
   SendBirdUserMessageParams.JSON_PROPERTY_TRANSLATION_TARGET_LANGUAGES
 })
 @JsonTypeName("SendBird.UserMessageParams")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBirdUserMessageParams {
   public static final String JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS = "apple_critical_alert_options";
   private SendBirdAppleCriticalAlertOptions appleCriticalAlertOptions;
@@ -184,7 +184,7 @@ public class SendBirdUserMessageParams {
    * Get appleCriticalAlertOptions
    * @return appleCriticalAlertOptions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -210,7 +210,7 @@ public class SendBirdUserMessageParams {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -236,7 +236,7 @@ public class SendBirdUserMessageParams {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -262,7 +262,7 @@ public class SendBirdUserMessageParams {
    * Get isReplyToChannel
    * @return isReplyToChannel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_REPLY_TO_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -288,7 +288,7 @@ public class SendBirdUserMessageParams {
    * Get mentionType
    * @return mentionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -322,7 +322,7 @@ public class SendBirdUserMessageParams {
    * Get mentionedUserIds
    * @return mentionedUserIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -356,7 +356,7 @@ public class SendBirdUserMessageParams {
    * Get mentionedUsers
    * @return mentionedUsers
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -382,7 +382,7 @@ public class SendBirdUserMessageParams {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -416,7 +416,7 @@ public class SendBirdUserMessageParams {
    * Get metaArrayKeys
    * @return metaArrayKeys
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_META_ARRAY_KEYS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -450,7 +450,7 @@ public class SendBirdUserMessageParams {
    * Get metaArrays
    * @return metaArrays
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_META_ARRAYS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -476,7 +476,7 @@ public class SendBirdUserMessageParams {
    * Get parentMessageId
    * @return parentMessageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PARENT_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -502,7 +502,7 @@ public class SendBirdUserMessageParams {
    * Get pollId
    * @return pollId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_POLL_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -528,7 +528,7 @@ public class SendBirdUserMessageParams {
    * Get pushNotificationDeliveryOption
    * @return pushNotificationDeliveryOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_NOTIFICATION_DELIVERY_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -562,7 +562,7 @@ public class SendBirdUserMessageParams {
    * Get targetLanguages
    * @return targetLanguages
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_LANGUAGES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -596,7 +596,7 @@ public class SendBirdUserMessageParams {
    * Get translationTargetLanguages
    * @return translationTargetLanguages
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TRANSLATION_TARGET_LANGUAGES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBotSMessageData.java
+++ b/src/main/java/org/openapitools/client/model/SendBotSMessageData.java
@@ -48,7 +48,7 @@ import org.sendbird.client.JSON;
   SendBotSMessageData.JSON_PROPERTY_TARGET_MESSAGE_ID
 })
 @JsonTypeName("sendBot_sMessageData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBotSMessageData {
   public static final String JSON_PROPERTY_MESSAGE = "message";
   private String message;
@@ -95,7 +95,7 @@ public class SendBotSMessageData {
    * Specifies the content of the message sent by the bot.
    * @return message
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the content of the message sent by the bot.")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -121,7 +121,7 @@ public class SendBotSMessageData {
    * Specifies the URL of the channel where the message is sent to.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the channel where the message is sent to.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -147,7 +147,7 @@ public class SendBotSMessageData {
    * Specifies a custom message type which is used for message grouping. The length is limited to 128 characters.
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies a custom message type which is used for message grouping. The length is limited to 128 characters.")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -173,7 +173,7 @@ public class SendBotSMessageData {
    * Specifies additional message information such as custom font size, font type or &#x60;JSON&#x60; formatted string.
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional message information such as custom font size, font type or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -199,7 +199,7 @@ public class SendBotSMessageData {
    * Determines whether to send a push notification for the message to the members of the channel (Default: true)
    * @return sendPush
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to send a push notification for the message to the members of the channel (Default: true)")
   @JsonProperty(JSON_PROPERTY_SEND_PUSH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -233,7 +233,7 @@ public class SendBotSMessageData {
    * Specifies an array of one or more IDs of the users who get a notification for the message.
    * @return mentioned
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more IDs of the users who get a notification for the message.")
   @JsonProperty(JSON_PROPERTY_MENTIONED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -259,7 +259,7 @@ public class SendBotSMessageData {
    * Determines whether to mark the message as read for the bot. If set to false, the bot&#39;s unread_count and read_receipt remain unchanged after the message is sent. (Default: true)
    * @return markAsRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to mark the message as read for the bot. If set to false, the bot's unread_count and read_receipt remain unchanged after the message is sent. (Default: true)")
   @JsonProperty(JSON_PROPERTY_MARK_AS_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -285,7 +285,7 @@ public class SendBotSMessageData {
    * Specifies the unique ID for the message to prevent the same message data from getting sent to the channel.
    * @return dedupId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID for the message to prevent the same message data from getting sent to the channel.")
   @JsonProperty(JSON_PROPERTY_DEDUP_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -311,7 +311,7 @@ public class SendBotSMessageData {
    * Specifies the time that the message was sent, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format.
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time that the message was sent, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format.")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -337,7 +337,7 @@ public class SendBotSMessageData {
    * Get extendedMessagePayload
    * @return extendedMessagePayload
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_EXTENDED_MESSAGE_PAYLOAD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -363,7 +363,7 @@ public class SendBotSMessageData {
    * Specifies the ID of the user&#39;s message which bot&#39;s message replies to
    * @return targetMessageId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the ID of the user's message which bot's message replies to")
   @JsonProperty(JSON_PROPERTY_TARGET_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendBotSMessageDataExtendedMessagePayload.java
+++ b/src/main/java/org/openapitools/client/model/SendBotSMessageDataExtendedMessagePayload.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBotSMessageDataExtendedMessagePayload.JSON_PROPERTY_CUSTOM_VIEW
 })
 @JsonTypeName("sendBot_sMessageData_extended_message_payload")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendBotSMessageDataExtendedMessagePayload {
   public static final String JSON_PROPERTY_SUGGESTED_REPLIES = "suggested_replies";
   private List<String> suggestedReplies = null;
@@ -67,7 +67,7 @@ public class SendBotSMessageDataExtendedMessagePayload {
    * Specifies an array of suggested replies to be sent with the message.
    * @return suggestedReplies
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of suggested replies to be sent with the message.")
   @JsonProperty(JSON_PROPERTY_SUGGESTED_REPLIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class SendBotSMessageDataExtendedMessagePayload {
    * JSON format you want to embed in message, eq : {\&quot;title\&quot;: \&quot;title\&quot;, \&quot;image\&quot;: \&quot;https://link.to/image.jpg\&quot;}
    * @return customView
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "JSON format you want to embed in message, eq : {\"title\": \"title\", \"image\": \"https://link.to/image.jpg\"}")
   @JsonProperty(JSON_PROPERTY_CUSTOM_VIEW)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SendMessageData.java
+++ b/src/main/java/org/openapitools/client/model/SendMessageData.java
@@ -63,7 +63,7 @@ import org.sendbird.client.JSON;
   SendMessageData.JSON_PROPERTY_THUMBNAIL3
 })
 @JsonTypeName("sendMessageData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SendMessageData {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -155,7 +155,7 @@ public class SendMessageData {
    * Specifies the user ID of the sender.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the user ID of the sender.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -181,7 +181,7 @@ public class SendMessageData {
    * Specifies the type of the channel. Either open_channels or group_channels.
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the type of the channel. Either open_channels or group_channels.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -207,7 +207,7 @@ public class SendMessageData {
    * Specifies the URL of the channel to send a message to.
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the channel to send a message to.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -233,7 +233,7 @@ public class SendMessageData {
    * Specifies the type of the message as MESG, FILE or ADMM
    * @return messageType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the type of the message as MESG, FILE or ADMM")
   @JsonProperty(JSON_PROPERTY_MESSAGE_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -259,7 +259,7 @@ public class SendMessageData {
    * Specifies the content of the message.
    * @return message
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the content of the message.")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -285,7 +285,7 @@ public class SendMessageData {
    * Specifies a custom message type which is used for message grouping. The length is limited to 128 characters.&lt;br /&gt;&lt;br /&gt; Custom types are also used within Sendbird&#39;s [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies a custom message type which is used for message grouping. The length is limited to 128 characters.<br /><br /> Custom types are also used within Sendbird's [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -311,7 +311,7 @@ public class SendMessageData {
    * Specifies additional message information such as custom font size, font type or &#x60;JSON&#x60; formatted string.
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional message information such as custom font size, font type or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -337,7 +337,7 @@ public class SendMessageData {
    * Determines whether to send a push notification for the message to the members of the channel (applicable to group channels only). Unlike text and file messages, a push notification for an admin message is not sent by default. (Default: true)
    * @return sendPush
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to send a push notification for the message to the members of the channel (applicable to group channels only). Unlike text and file messages, a push notification for an admin message is not sent by default. (Default: true)")
   @JsonProperty(JSON_PROPERTY_SEND_PUSH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -363,7 +363,7 @@ public class SendMessageData {
    * Specifies the mentioning type which indicates the user scope who will get a notification for the message. Acceptable values are users and channel. If set to users, only the specified users with the mentioned_users property below will get notified. If set to channel, all users in the channel will get notified. (Default: users)
    * @return mentionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the mentioning type which indicates the user scope who will get a notification for the message. Acceptable values are users and channel. If set to users, only the specified users with the mentioned_users property below will get notified. If set to channel, all users in the channel will get notified. (Default: users)")
   @JsonProperty(JSON_PROPERTY_MENTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -397,7 +397,7 @@ public class SendMessageData {
    * Specifies an array of one or more IDs of the users who will get a notification for the message.
    * @return mentionedUserIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more IDs of the users who will get a notification for the message.")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -423,7 +423,7 @@ public class SendMessageData {
    * Determines whether to send a message without updating some of the channel properties. If a message is sent in a channel, with this property set to true, the channel&#39;s last_message is updated only for the sender while its unread_message_count remains unchanged for all channel members. Also, the message doesn&#39;t send a push notification to message receivers. If the message is sent to a hidden channel, the channel still remains hidden. (Default: false)&lt;/br&gt;&lt;/br&gt;  Once the value of this property is set, it can&#39;t be reverted.
    * @return isSilent
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to send a message without updating some of the channel properties. If a message is sent in a channel, with this property set to true, the channel's last_message is updated only for the sender while its unread_message_count remains unchanged for all channel members. Also, the message doesn't send a push notification to message receivers. If the message is sent to a hidden channel, the channel still remains hidden. (Default: false)</br></br>  Once the value of this property is set, it can't be reverted.")
   @JsonProperty(JSON_PROPERTY_IS_SILENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -449,7 +449,7 @@ public class SendMessageData {
    * Specifies a &#x60;JSON&#x60; object of one or more key-values items which store additional message information. Each item consists of a key and the values in an array. Items are saved and will be returned in the exact order they&#39;ve been specified.
    * @return sortedMetaarray
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies a `JSON` object of one or more key-values items which store additional message information. Each item consists of a key and the values in an array. Items are saved and will be returned in the exact order they've been specified.")
   @JsonProperty(JSON_PROPERTY_SORTED_METAARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -475,7 +475,7 @@ public class SendMessageData {
    * Specifies the time that the message was sent, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. This property can be used when migrating the messages of other system to Sendbird server. If specified, the server sets the message&#39;s creation time as the property value.
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time that the message was sent, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. This property can be used when migrating the messages of other system to Sendbird server. If specified, the server sets the message's creation time as the property value.")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -501,7 +501,7 @@ public class SendMessageData {
    * Specifies the unique message ID created by other system. In general, this property is used to prevent the same message data from getting inserted when migrating the messages of the other system to Sendbird server. If specified, the server performs a duplicate check using the property value.
    * @return dedupId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique message ID created by other system. In general, this property is used to prevent the same message data from getting inserted when migrating the messages of the other system to Sendbird server. If specified, the server performs a duplicate check using the property value.")
   @JsonProperty(JSON_PROPERTY_DEDUP_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -527,7 +527,7 @@ public class SendMessageData {
    * Specifies the bundle ID of the client app in order to send a push notification to iOS devices. You can find this in Settings &gt; Chat &gt; Notifications &gt; Push notification services
    * @return apnsBundleId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the bundle ID of the client app in order to send a push notification to iOS devices. You can find this in Settings > Chat > Notifications > Push notification services")
   @JsonProperty(JSON_PROPERTY_APNS_BUNDLE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -553,7 +553,7 @@ public class SendMessageData {
    * Specifies the name of the file that sounds for critical alerts.
    * @return sound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the name of the file that sounds for critical alerts.")
   @JsonProperty(JSON_PROPERTY_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -579,7 +579,7 @@ public class SendMessageData {
    * Specifies the volume of the critical alert sound. The volume ranges from 0.0 to 1.0, which indicates silent and full volume, respectively. (Default 1.0)
    * @return volume
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the volume of the critical alert sound. The volume ranges from 0.0 to 1.0, which indicates silent and full volume, respectively. (Default 1.0)")
   @JsonProperty(JSON_PROPERTY_VOLUME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -605,7 +605,7 @@ public class SendMessageData {
    * Get url
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -631,7 +631,7 @@ public class SendMessageData {
    * Get _file
    * @return _file
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -657,7 +657,7 @@ public class SendMessageData {
    * Get fileName
    * @return fileName
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -683,7 +683,7 @@ public class SendMessageData {
    * Get fileSize
    * @return fileSize
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE_SIZE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -709,7 +709,7 @@ public class SendMessageData {
    * Get fileType
    * @return fileType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -743,7 +743,7 @@ public class SendMessageData {
    * Get thumbnails
    * @return thumbnails
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_THUMBNAILS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -769,7 +769,7 @@ public class SendMessageData {
    * Get thumbnail1
    * @return thumbnail1
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_THUMBNAIL1)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -795,7 +795,7 @@ public class SendMessageData {
    * Get thumbnail2
    * @return thumbnail2
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_THUMBNAIL2)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -821,7 +821,7 @@ public class SendMessageData {
    * Get thumbnail3
    * @return thumbnail3
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_THUMBNAIL3)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterData.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterData.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterData.JSON_PROPERTY_IMAGE_MODERATION
 })
 @JsonTypeName("setDomainFilterData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SetDomainFilterData {
   public static final String JSON_PROPERTY_DOMAIN_FILTER = "domain_filter";
   private SetDomainFilterDataDomainFilter domainFilter;
@@ -68,7 +68,7 @@ public class SetDomainFilterData {
    * Get domainFilter
    * @return domainFilter
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DOMAIN_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class SetDomainFilterData {
    * Get profanityFilter
    * @return profanityFilter
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFANITY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -120,7 +120,7 @@ public class SetDomainFilterData {
    * Get profanityTriggeredModeration
    * @return profanityTriggeredModeration
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFANITY_TRIGGERED_MODERATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -146,7 +146,7 @@ public class SetDomainFilterData {
    * Get imageModeration
    * @return imageModeration
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IMAGE_MODERATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataDomainFilter.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataDomainFilter.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataDomainFilter.JSON_PROPERTY_SHOULD_CHECK_GLOBAL
 })
 @JsonTypeName("setDomainFilterData_domain_filter")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SetDomainFilterDataDomainFilter {
   public static final String JSON_PROPERTY_DOMAINS = "domains";
   private List<String> domains = null;
@@ -70,7 +70,7 @@ public class SetDomainFilterDataDomainFilter {
    * Get domains
    * @return domains
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DOMAINS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -96,7 +96,7 @@ public class SetDomainFilterDataDomainFilter {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -122,7 +122,7 @@ public class SetDomainFilterDataDomainFilter {
    * Get shouldCheckGlobal
    * @return shouldCheckGlobal
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SHOULD_CHECK_GLOBAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataImageModeration.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataImageModeration.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataImageModeration.JSON_PROPERTY_CHECK_URLS
 })
 @JsonTypeName("setDomainFilterData_image_moderation")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SetDomainFilterDataImageModeration {
   public static final String JSON_PROPERTY_TYPE = "type";
   private Integer type;
@@ -65,7 +65,7 @@ public class SetDomainFilterDataImageModeration {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -91,7 +91,7 @@ public class SetDomainFilterDataImageModeration {
    * Get softBlock
    * @return softBlock
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SOFT_BLOCK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -117,7 +117,7 @@ public class SetDomainFilterDataImageModeration {
    * Get limits
    * @return limits
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_LIMITS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -143,7 +143,7 @@ public class SetDomainFilterDataImageModeration {
    * Get checkUrls
    * @return checkUrls
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHECK_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataImageModerationLimits.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataImageModerationLimits.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataImageModerationLimits.JSON_PROPERTY_RACY
 })
 @JsonTypeName("setDomainFilterData_image_moderation_limits")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SetDomainFilterDataImageModerationLimits {
   public static final String JSON_PROPERTY_ADULT = "adult";
   private Integer adult;
@@ -68,7 +68,7 @@ public class SetDomainFilterDataImageModerationLimits {
    * Get adult
    * @return adult
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ADULT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -94,7 +94,7 @@ public class SetDomainFilterDataImageModerationLimits {
    * Get spoof
    * @return spoof
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SPOOF)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -120,7 +120,7 @@ public class SetDomainFilterDataImageModerationLimits {
    * Get medical
    * @return medical
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MEDICAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -146,7 +146,7 @@ public class SetDomainFilterDataImageModerationLimits {
    * Get violence
    * @return violence
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VIOLENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -172,7 +172,7 @@ public class SetDomainFilterDataImageModerationLimits {
    * Get racy
    * @return racy
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_RACY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityFilter.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityFilter.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataProfanityFilter.JSON_PROPERTY_SHOULD_CHECK_GLOBAL
 })
 @JsonTypeName("setDomainFilterData_profanity_filter")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SetDomainFilterDataProfanityFilter {
   public static final String JSON_PROPERTY_KEYWORDS = "keywords";
   private List<String> keywords = null;
@@ -75,7 +75,7 @@ public class SetDomainFilterDataProfanityFilter {
    * Get keywords
    * @return keywords
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_KEYWORDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -109,7 +109,7 @@ public class SetDomainFilterDataProfanityFilter {
    * Get regexFilters
    * @return regexFilters
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REGEX_FILTERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -135,7 +135,7 @@ public class SetDomainFilterDataProfanityFilter {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -161,7 +161,7 @@ public class SetDomainFilterDataProfanityFilter {
    * Get shouldCheckGlobal
    * @return shouldCheckGlobal
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SHOULD_CHECK_GLOBAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityFilterRegexFiltersInner.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityFilterRegexFiltersInner.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataProfanityFilterRegexFiltersInner.JSON_PROPERTY_REGEX
 })
 @JsonTypeName("setDomainFilterData_profanity_filter_regex_filters_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SetDomainFilterDataProfanityFilterRegexFiltersInner {
   public static final String JSON_PROPERTY_REGEX = "regex";
   private String regex;
@@ -52,7 +52,7 @@ public class SetDomainFilterDataProfanityFilterRegexFiltersInner {
    * Get regex
    * @return regex
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REGEX)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityTriggeredModeration.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityTriggeredModeration.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataProfanityTriggeredModeration.JSON_PROPERTY_ACTION
 })
 @JsonTypeName("setDomainFilterData_profanity_triggered_moderation")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class SetDomainFilterDataProfanityTriggeredModeration {
   public static final String JSON_PROPERTY_COUNT = "count";
   private Integer count;
@@ -60,7 +60,7 @@ public class SetDomainFilterDataProfanityTriggeredModeration {
    * Get count
    * @return count
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -86,7 +86,7 @@ public class SetDomainFilterDataProfanityTriggeredModeration {
    * Get duration
    * @return duration
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DURATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -112,7 +112,7 @@ public class SetDomainFilterDataProfanityTriggeredModeration {
    * Get action
    * @return action
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ACTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/TranslateMessageIntoOtherLanguagesData.java
+++ b/src/main/java/org/openapitools/client/model/TranslateMessageIntoOtherLanguagesData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   TranslateMessageIntoOtherLanguagesData.JSON_PROPERTY_TARGET_LANGS
 })
 @JsonTypeName("translateMessageIntoOtherLanguagesData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class TranslateMessageIntoOtherLanguagesData {
   public static final String JSON_PROPERTY_TARGET_LANGS = "target_langs";
   private List<String> targetLangs = null;
@@ -62,7 +62,7 @@ public class TranslateMessageIntoOtherLanguagesData {
    * Specifies an array of one or more codes of [translation](/docs/chat/v3/platform-api/message/translations/translation-engine) to translate the message.
    * @return targetLangs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more codes of [translation](/docs/chat/v3/platform-api/message/translations/translation-engine) to translate the message.")
   @JsonProperty(JSON_PROPERTY_TARGET_LANGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdData.java
@@ -51,7 +51,7 @@ import org.sendbird.client.JSON;
   UpdateAnnouncementByIdData.JSON_PROPERTY_RESUME_AT
 })
 @JsonTypeName("updateAnnouncementByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateAnnouncementByIdData {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;
@@ -116,7 +116,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the unique ID of the announcement to update.
    * @return uniqueId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the announcement to update.")
   @JsonProperty(JSON_PROPERTY_UNIQUE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -142,7 +142,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies an action to take on the announcement. If this property is updated, other specified properties in the request are not effective. Acceptable values are limited to remove, pause, resume, and cancel. The [Announcement actions](#2-update-an-announcement-3-how-to-change-announcement-status) table explains each action in detail.
    * @return action
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an action to take on the announcement. If this property is updated, other specified properties in the request are not effective. Acceptable values are limited to remove, pause, resume, and cancel. The [Announcement actions](#2-update-an-announcement-3-how-to-change-announcement-status) table explains each action in detail.")
   @JsonProperty(JSON_PROPERTY_ACTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -168,7 +168,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the name of an announcement group to retrieve. If not specified, all announcements are returned, regardless of their group.
    * @return announcementGroup
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the name of an announcement group to retrieve. If not specified, all announcements are returned, regardless of their group.")
   @JsonProperty(JSON_PROPERTY_ANNOUNCEMENT_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -194,7 +194,7 @@ public class UpdateAnnouncementByIdData {
    * Determines whether to create a new channel if there is no existing channel that matches with the target options including target_at and target_list.
    * @return createChannel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to create a new channel if there is no existing channel that matches with the target options including target_at and target_list.")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -220,7 +220,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the name of the channel. (Default: Group Channel)
    * @return createChannelOptionsName
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the name of the channel. (Default: Group Channel)")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -246,7 +246,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the URL of the cover image.
    * @return createChannelOptionsCoverUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the cover image.")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS_COVER_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -272,7 +272,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the custom channel type.
    * @return createChannelOptionsCustomType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the custom channel type.")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -298,7 +298,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies additional channel information such as a long description of the channel or &#x60;JSON&#x60; formatted string.
    * @return createChannelOptionsData
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional channel information such as a long description of the channel or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -324,7 +324,7 @@ public class UpdateAnnouncementByIdData {
    * Determines whether to create a [distinct](/docs/chat/v3/platform-api/guides/channel-types#2-group-channel) channel. (Default: true)
    * @return createChannelOptionsDistinct
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to create a [distinct](/docs/chat/v3/platform-api/guides/channel-types#2-group-channel) channel. (Default: true)")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS_DISTINCT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -350,7 +350,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the unique ID of the announcement sender.
    * @return messageUserId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of the announcement sender.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -376,7 +376,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the content of the message.
    * @return messageContent
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the content of the message.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_CONTENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -402,7 +402,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies additional message information such as custom font size, font type or &#x60;JSON&#x60; formatted string.
    * @return messageData
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional message information such as custom font size, font type or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -428,7 +428,7 @@ public class UpdateAnnouncementByIdData {
    * Determines whether to turn on push notification for the announcement. If set to true, push notifications will be sent for announcements.
    * @return enablePush
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to turn on push notification for the announcement. If set to true, push notifications will be sent for announcements.")
   @JsonProperty(JSON_PROPERTY_ENABLE_PUSH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -454,7 +454,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the time to start the announcement, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. (Default: current timestamp)
    * @return scheduledAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time to start the announcement, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. (Default: current timestamp)")
   @JsonProperty(JSON_PROPERTY_SCHEDULED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -480,7 +480,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the time to permanently end the announcement, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format, even if the announcement is not sent to all its targets.
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time to permanently end the announcement, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format, even if the announcement is not sent to all its targets.")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -506,7 +506,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the time to temporarily put the announcement on hold in UTC. The string is represented in HHMM format. This property should be specified in conjunction with the resume_at below.
    * @return ceaseAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time to temporarily put the announcement on hold in UTC. The string is represented in HHMM format. This property should be specified in conjunction with the resume_at below.")
   @JsonProperty(JSON_PROPERTY_CEASE_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -532,7 +532,7 @@ public class UpdateAnnouncementByIdData {
    * Specifies the time to automatically resume the on-hold announcement in UTC. The string is represented in HHMM format. This property should be specified in conjunction with the cease_at above.
    * @return resumeAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time to automatically resume the on-hold announcement in UTC. The string is represented in HHMM format. This property should be specified in conjunction with the cease_at above.")
   @JsonProperty(JSON_PROPERTY_RESUME_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   UpdateAnnouncementByIdResponse.JSON_PROPERTY_MESSAGE
 })
 @JsonTypeName("updateAnnouncementByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateAnnouncementByIdResponse {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;
@@ -61,7 +61,7 @@ public class UpdateAnnouncementByIdResponse {
    * Get uniqueId
    * @return uniqueId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNIQUE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -87,7 +87,7 @@ public class UpdateAnnouncementByIdResponse {
    * Get announcementGroup
    * @return announcementGroup
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ANNOUNCEMENT_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -113,7 +113,7 @@ public class UpdateAnnouncementByIdResponse {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdResponseMessage.java
+++ b/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdResponseMessage.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   UpdateAnnouncementByIdResponseMessage.JSON_PROPERTY_OPEN_RATE
 })
 @JsonTypeName("updateAnnouncementByIdResponse_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateAnnouncementByIdResponseMessage {
   public static final String JSON_PROPERTY_TYPE = "type";
   private String type;
@@ -109,7 +109,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get type
    * @return type
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -135,7 +135,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get customType
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -161,7 +161,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -187,7 +187,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get content
    * @return content
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CONTENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -213,7 +213,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get data
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -239,7 +239,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get enablePush
    * @return enablePush
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_PUSH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -265,7 +265,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get targetAt
    * @return targetAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -291,7 +291,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get targetUserCount
    * @return targetUserCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_USER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -317,7 +317,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get targetChannelCount
    * @return targetChannelCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_CHANNEL_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -343,7 +343,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -369,7 +369,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get scheduledAt
    * @return scheduledAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SCHEDULED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -395,7 +395,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get completedAt
    * @return completedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COMPLETED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -421,7 +421,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get sentUserCount
    * @return sentUserCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENT_USER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -447,7 +447,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get openCount
    * @return openCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -473,7 +473,7 @@ public class UpdateAnnouncementByIdResponseMessage {
    * Get openRate
    * @return openRate
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_RATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateApnsPushConfigurationByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateApnsPushConfigurationByIdData.java
@@ -44,7 +44,7 @@ import org.sendbird.client.JSON;
   UpdateApnsPushConfigurationByIdData.JSON_PROPERTY_APNS_TYPE
 })
 @JsonTypeName("updateApnsPushConfigurationByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateApnsPushConfigurationByIdData {
   public static final String JSON_PROPERTY_PROVIDER_ID = "provider_id";
   private String providerId;
@@ -85,7 +85,7 @@ public class UpdateApnsPushConfigurationByIdData {
    * Specifies the provider ID of the push configuration to update.
    * @return providerId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the provider ID of the push configuration to update.")
   @JsonProperty(JSON_PROPERTY_PROVIDER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -111,7 +111,7 @@ public class UpdateApnsPushConfigurationByIdData {
    * In a form of the &#x60;multipart/form-data&#x60; content type, specifies a [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file of which type is either development or production. Sendbird server scans the content of the file, finds out the certificate type, and then registers the file as the corresponding type. If you upload a wrong file, you will receive an error. You should specify either this property or the apns_type below to inform the server of which certificate type to update.
    * @return apnsCert
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "In a form of the `multipart/form-data` content type, specifies a [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file of which type is either development or production. Sendbird server scans the content of the file, finds out the certificate type, and then registers the file as the corresponding type. If you upload a wrong file, you will receive an error. You should specify either this property or the apns_type below to inform the server of which certificate type to update.")
   @JsonProperty(JSON_PROPERTY_APNS_CERT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -137,7 +137,7 @@ public class UpdateApnsPushConfigurationByIdData {
    * Specifies the certificate type of the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file. Acceptable values are development and production. You should specify either this property or the apns_cert above to inform the server of which certificate type to update.
    * @return apnsCertEnvType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the certificate type of the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file. Acceptable values are development and production. You should specify either this property or the apns_cert above to inform the server of which certificate type to update.")
   @JsonProperty(JSON_PROPERTY_APNS_CERT_ENV_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -163,7 +163,7 @@ public class UpdateApnsPushConfigurationByIdData {
    * Specifies the password of the cerfificate file which has been set during the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) export.
    * @return apnsCertPassword
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the password of the cerfificate file which has been set during the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) export.")
   @JsonProperty(JSON_PROPERTY_APNS_CERT_PASSWORD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -189,7 +189,7 @@ public class UpdateApnsPushConfigurationByIdData {
    * Determines whether to badge your client app&#39;s icon with the number of a user&#39;s unread messages. (Default: true)
    * @return hasUnreadCountBadge
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to badge your client app's icon with the number of a user's unread messages. (Default: true)")
   @JsonProperty(JSON_PROPERTY_HAS_UNREAD_COUNT_BADGE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -215,7 +215,7 @@ public class UpdateApnsPushConfigurationByIdData {
    * Determines for your client app whether to perform a silent background update on a user&#39;s device. For more information, see the Apple Developer Documentation&#39;s [Pushing Updates to Your App Silently](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_updates_to_your_app_silently). (Default: false)
    * @return contentAvailable
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines for your client app whether to perform a silent background update on a user's device. For more information, see the Apple Developer Documentation's [Pushing Updates to Your App Silently](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_updates_to_your_app_silently). (Default: false)")
   @JsonProperty(JSON_PROPERTY_CONTENT_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -241,7 +241,7 @@ public class UpdateApnsPushConfigurationByIdData {
    * Determines for your client app whether or not to modify the payload of a push notification before it is displayed on a user&#39;s device. For more information, see the Apple Developer Documentation&#39;s [Modifying Content in Newly Delivered Notifications](https://developer.apple.com/documentation/usernotifications/modifying_content_in_newly_delivered_notifications). (Default: false)
    * @return mutableContent
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines for your client app whether or not to modify the payload of a push notification before it is displayed on a user's device. For more information, see the Apple Developer Documentation's [Modifying Content in Newly Delivered Notifications](https://developer.apple.com/documentation/usernotifications/modifying_content_in_newly_delivered_notifications). (Default: false)")
   @JsonProperty(JSON_PROPERTY_MUTABLE_CONTENT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -267,7 +267,7 @@ public class UpdateApnsPushConfigurationByIdData {
    * Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file can be in the app&#39;s main bundle or in the &#x60;Library/Sounds&#x60; folder of the app&#39;s data container.
    * @return pushSound
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file can be in the app's main bundle or in the `Library/Sounds` folder of the app's data container.")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -293,7 +293,7 @@ public class UpdateApnsPushConfigurationByIdData {
    * (Deprecated)  Specifies the certificate type of the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file. Acceptable values are development and production. You should specify either this property or the apns_cert above to inform the server of which certificate type to update.
    * @return apnsType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "(Deprecated)  Specifies the certificate type of the [.p12](/docs/chat/v3/ios/guides/push-notifications#2-step-3-export-a-p12-file-and-upload-to-sendbird-dashboard) file. Acceptable values are development and production. You should specify either this property or the apns_cert above to inform the server of which certificate type to update.")
   @JsonProperty(JSON_PROPERTY_APNS_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateApnsPushConfigurationByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateApnsPushConfigurationByIdResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateApnsPushConfigurationByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("updateApnsPushConfigurationByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateApnsPushConfigurationByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private String pushConfigurations;
@@ -52,7 +52,7 @@ public class UpdateApnsPushConfigurationByIdResponse {
    * Get pushConfigurations
    * @return pushConfigurations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_CONFIGURATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateBotByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateBotByIdData.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   UpdateBotByIdData.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("updateBotByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateBotByIdData {
   public static final String JSON_PROPERTY_BOT_USERID = "bot_userid";
   private String botUserid;
@@ -80,7 +80,7 @@ public class UpdateBotByIdData {
    * Specifies the ID of the bot to update.
    * @return botUserid
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the ID of the bot to update.")
   @JsonProperty(JSON_PROPERTY_BOT_USERID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -106,7 +106,7 @@ public class UpdateBotByIdData {
    * Specifies the bot&#39;s nickname. The length is limited to 80 characters.
    * @return botNickname
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the bot's nickname. The length is limited to 80 characters.")
   @JsonProperty(JSON_PROPERTY_BOT_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -132,7 +132,7 @@ public class UpdateBotByIdData {
    * Specifies the URL of the bot&#39;s profile image. The size is limited to 2,048 characters.
    * @return botProfileUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the bot's profile image. The size is limited to 2,048 characters.")
   @JsonProperty(JSON_PROPERTY_BOT_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -158,7 +158,7 @@ public class UpdateBotByIdData {
    * Specifies the server URL where bot is located to receive all events, requests, and data forwarded from an application. For security reasons, it is highly recommended that you use an SSL server. The length is limited to 1,024 characters.
    * @return botCallbackUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the server URL where bot is located to receive all events, requests, and data forwarded from an application. For security reasons, it is highly recommended that you use an SSL server. The length is limited to 1,024 characters.")
   @JsonProperty(JSON_PROPERTY_BOT_CALLBACK_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -184,7 +184,7 @@ public class UpdateBotByIdData {
    * In the channels of where the bot is a member, determines whether to only forward the messages with the specific conditions to the bot or forword all messages to the bot, for privacy concerns. If set to true, only messages that start with a &#39;/&#39; or mention the bot_userid are forwarded to the bot. If set to false, all messages are forwarded.
    * @return isPrivacyMode
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "In the channels of where the bot is a member, determines whether to only forward the messages with the specific conditions to the bot or forword all messages to the bot, for privacy concerns. If set to true, only messages that start with a '/' or mention the bot_userid are forwarded to the bot. If set to false, all messages are forwarded.")
   @JsonProperty(JSON_PROPERTY_IS_PRIVACY_MODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -210,7 +210,7 @@ public class UpdateBotByIdData {
    * Determines whether to mark the bot&#39;s message as read upon sending it. (Default: true)
    * @return enableMarkAsRead
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to mark the bot's message as read upon sending it. (Default: true)")
   @JsonProperty(JSON_PROPERTY_ENABLE_MARK_AS_READ)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -236,7 +236,7 @@ public class UpdateBotByIdData {
    * Determines whether to include information about the members of each channel in a callback response. (Default: false)
    * @return showMember
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to include information about the members of each channel in a callback response. (Default: false)")
   @JsonProperty(JSON_PROPERTY_SHOW_MEMBER)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -262,7 +262,7 @@ public class UpdateBotByIdData {
    * Determines whether the bot automatically joins the channel when invited or joins the channel after manually accepting an invitation using the API. If set to 0, it automatically joins the channel. If set to 1, the latter takes place. (Default: 0)
    * @return channelInvitationPreference
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether the bot automatically joins the channel when invited or joins the channel after manually accepting an invitation using the API. If set to 0, it automatically joins the channel. If set to 1, the latter takes place. (Default: 0)")
   @JsonProperty(JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateBotByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateBotByIdResponse.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   UpdateBotByIdResponse.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("updateBotByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateBotByIdResponse {
   public static final String JSON_PROPERTY_BOT = "bot";
   private CreateBotResponseBot bot;
@@ -74,7 +74,7 @@ public class UpdateBotByIdResponse {
    * Get bot
    * @return bot
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -100,7 +100,7 @@ public class UpdateBotByIdResponse {
    * Get botCallbackUrl
    * @return botCallbackUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT_CALLBACK_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -126,7 +126,7 @@ public class UpdateBotByIdResponse {
    * Get enableMarkAsRead
    * @return enableMarkAsRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_MARK_AS_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -152,7 +152,7 @@ public class UpdateBotByIdResponse {
    * Get isPrivacyMode
    * @return isPrivacyMode
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_PRIVACY_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -178,7 +178,7 @@ public class UpdateBotByIdResponse {
    * Get showMember
    * @return showMember
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SHOW_MEMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -204,7 +204,7 @@ public class UpdateBotByIdResponse {
    * Get channelInvitationPreference
    * @return channelInvitationPreference
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateChannelInvitationPreferenceData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateChannelInvitationPreferenceData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateChannelInvitationPreferenceData.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("updateChannelInvitationPreferenceData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateChannelInvitationPreferenceData {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;
@@ -52,7 +52,7 @@ public class UpdateChannelInvitationPreferenceData {
    * Determines for the user whether or not to automatically join a [private](/docs/chat/v3/platform-api/guides/group-channel#-3-private-vs-public) group channel promptly from an invitation without having to accept it. (Default: true)
    * @return autoAccept
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines for the user whether or not to automatically join a [private](/docs/chat/v3/platform-api/guides/group-channel#-3-private-vs-public) group channel promptly from an invitation without having to accept it. (Default: true)")
   @JsonProperty(JSON_PROPERTY_AUTO_ACCEPT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateChannelInvitationPreferenceResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateChannelInvitationPreferenceResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateChannelInvitationPreferenceResponse.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("updateChannelInvitationPreferenceResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateChannelInvitationPreferenceResponse {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;
@@ -52,7 +52,7 @@ public class UpdateChannelInvitationPreferenceResponse {
    * Get autoAccept
    * @return autoAccept
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_AUTO_ACCEPT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateChannelMetacounterData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateChannelMetacounterData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   UpdateChannelMetacounterData.JSON_PROPERTY_UPSERT
 })
 @JsonTypeName("updateChannelMetacounterData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateChannelMetacounterData {
   public static final String JSON_PROPERTY_METACOUNTER = "metacounter";
   private String metacounter;
@@ -60,7 +60,7 @@ public class UpdateChannelMetacounterData {
    * Specifies a &#x60;JSON&#x60; object that stores key-value items. The key must not have a comma (,) and its length is limited to 128 characters. The value must be an integer. This property can have up to 5 items.
    * @return metacounter
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a `JSON` object that stores key-value items. The key must not have a comma (,) and its length is limited to 128 characters. The value must be an integer. This property can have up to 5 items.")
   @JsonProperty(JSON_PROPERTY_METACOUNTER)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class UpdateChannelMetacounterData {
    * Specifies how to calculate the item value of the metacounter. Acceptable values are increase, decrease, and set. If set to increase, increments the item value of the metacounter by the value specified in the metacounter property, while decrease decrements. set sets the item value to the specified value exactly. (Default: set)
    * @return mode
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies how to calculate the item value of the metacounter. Acceptable values are increase, decrease, and set. If set to increase, increments the item value of the metacounter by the value specified in the metacounter property, while decrease decrements. set sets the item value to the specified value exactly. (Default: set)")
   @JsonProperty(JSON_PROPERTY_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -112,7 +112,7 @@ public class UpdateChannelMetacounterData {
    * Get upsert
    * @return upsert
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPSERT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateChannelMetadataData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateChannelMetadataData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   UpdateChannelMetadataData.JSON_PROPERTY_UPSERT
 })
 @JsonTypeName("updateChannelMetadataData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateChannelMetadataData {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   private Object metadata;
@@ -56,7 +56,7 @@ public class UpdateChannelMetadataData {
    * Specifies a &#x60;JSON&#x60; object which has key-value items to update. A key can&#39;t contain a comma (,) and its length is limited to 128 characters. A value must be a string and its length is limited to 190 characters. This property can have up to 5 items.
    * @return metadata
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a `JSON` object which has key-value items to update. A key can't contain a comma (,) and its length is limited to 128 characters. A value must be a string and its length is limited to 190 characters. This property can have up to 5 items.")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -82,7 +82,7 @@ public class UpdateChannelMetadataData {
    * Get upsert
    * @return upsert
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "")
   @JsonProperty(JSON_PROPERTY_UPSERT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateCountPreferenceOfChannelByUrlData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateCountPreferenceOfChannelByUrlData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateCountPreferenceOfChannelByUrlData.JSON_PROPERTY_COUNT_PREFERENCE
 })
 @JsonTypeName("updateCountPreferenceOfChannelByUrlData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateCountPreferenceOfChannelByUrlData {
   public static final String JSON_PROPERTY_COUNT_PREFERENCE = "count_preference";
   private String countPreference;
@@ -52,7 +52,7 @@ public class UpdateCountPreferenceOfChannelByUrlData {
    * Determines whether to only count the number of unread messages or the number of unread mentioned messages in the specified group channel. Only the one that is chosen to be preferenced will be counted and added to the total number count after the action. A value of off indicates that both read statuses will not be counted, while all indicates that both read statuses will be counted by the system. A value of unread_message_count_only indicates that only the user&#39;s unread messages will be counted in the channel while unread_mentioned_count_only indicates that only the user&#39;s unread mentioned messages will be counted. (Default: all)
    * @return countPreference
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to only count the number of unread messages or the number of unread mentioned messages in the specified group channel. Only the one that is chosen to be preferenced will be counted and added to the total number count after the action. A value of off indicates that both read statuses will not be counted, while all indicates that both read statuses will be counted by the system. A value of unread_message_count_only indicates that only the user's unread messages will be counted in the channel while unread_mentioned_count_only indicates that only the user's unread mentioned messages will be counted. (Default: all)")
   @JsonProperty(JSON_PROPERTY_COUNT_PREFERENCE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateCountPreferenceOfChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateCountPreferenceOfChannelByUrlResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateCountPreferenceOfChannelByUrlResponse.JSON_PROPERTY_COUNT_PREFERENCE
 })
 @JsonTypeName("updateCountPreferenceOfChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateCountPreferenceOfChannelByUrlResponse {
   public static final String JSON_PROPERTY_COUNT_PREFERENCE = "count_preference";
   private String countPreference;
@@ -52,7 +52,7 @@ public class UpdateCountPreferenceOfChannelByUrlResponse {
    * Get countPreference
    * @return countPreference
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COUNT_PREFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateDefaultChannelInvitationPreferenceData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateDefaultChannelInvitationPreferenceData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateDefaultChannelInvitationPreferenceData.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("updateDefaultChannelInvitationPreferenceData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateDefaultChannelInvitationPreferenceData {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;
@@ -52,7 +52,7 @@ public class UpdateDefaultChannelInvitationPreferenceData {
    * Determines for users within an application whether or not to automatically join a [private](/docs/chat/v3/platform-api/guides/group-channel#-3-private-vs-public) group channel promptly from an invitation without having to accept it. (Default: true)
    * @return autoAccept
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines for users within an application whether or not to automatically join a [private](/docs/chat/v3/platform-api/guides/group-channel#-3-private-vs-public) group channel promptly from an invitation without having to accept it. (Default: true)")
   @JsonProperty(JSON_PROPERTY_AUTO_ACCEPT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateDefaultChannelInvitationPreferenceResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateDefaultChannelInvitationPreferenceResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateDefaultChannelInvitationPreferenceResponse.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("updateDefaultChannelInvitationPreferenceResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateDefaultChannelInvitationPreferenceResponse {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;
@@ -52,7 +52,7 @@ public class UpdateDefaultChannelInvitationPreferenceResponse {
    * Get autoAccept
    * @return autoAccept
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_AUTO_ACCEPT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateEmojiCategoryUrlByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateEmojiCategoryUrlByIdData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   UpdateEmojiCategoryUrlByIdData.JSON_PROPERTY_URL
 })
 @JsonTypeName("updateEmojiCategoryUrlByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateEmojiCategoryUrlByIdData {
   public static final String JSON_PROPERTY_EMOJI_CATEGORY_ID = "emoji_category_id";
   private Integer emojiCategoryId;
@@ -56,7 +56,7 @@ public class UpdateEmojiCategoryUrlByIdData {
    * Specifies the unique ID of the emoji category to update.
    * @return emojiCategoryId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the emoji category to update.")
   @JsonProperty(JSON_PROPERTY_EMOJI_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -82,7 +82,7 @@ public class UpdateEmojiCategoryUrlByIdData {
    * Specifies the new URL of the emoji category.
    * @return url
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the new URL of the emoji category.")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateEmojiUrlByKeyData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateEmojiUrlByKeyData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   UpdateEmojiUrlByKeyData.JSON_PROPERTY_URL
 })
 @JsonTypeName("updateEmojiUrlByKeyData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateEmojiUrlByKeyData {
   public static final String JSON_PROPERTY_EMOJI_KEY = "emoji_key";
   private String emojiKey;
@@ -56,7 +56,7 @@ public class UpdateEmojiUrlByKeyData {
    * Specifies the key of the emoji to update.
    * @return emojiKey
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the key of the emoji to update.")
   @JsonProperty(JSON_PROPERTY_EMOJI_KEY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -82,7 +82,7 @@ public class UpdateEmojiUrlByKeyData {
    * Specifies the new image URL of the emoji.
    * @return url
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the new image URL of the emoji.")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageData.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   UpdateExtraDataInMessageData.JSON_PROPERTY_UPSERT
 })
 @JsonTypeName("updateExtraDataInMessageData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateExtraDataInMessageData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;
@@ -72,7 +72,7 @@ public class UpdateExtraDataInMessageData {
    * Specifies the type of the channel. Either open_channels or group_channels.
    * @return channelType
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the type of the channel. Either open_channels or group_channels.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -98,7 +98,7 @@ public class UpdateExtraDataInMessageData {
    * Specifies the URL of the target channel.
    * @return channelUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the target channel.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -124,7 +124,7 @@ public class UpdateExtraDataInMessageData {
    * Specifies the unique ID of the message to update key-values items.
    * @return messageId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the message to update key-values items.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -150,7 +150,7 @@ public class UpdateExtraDataInMessageData {
    * Specifies a &#x60;JSON&#x60; object of one or more key-values items which store additional message information. Each item consists of a key and the values in an array. Items are saved and will be returned in the exact order they&#39;ve been specified.
    * @return sortedMetaarray
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a `JSON` object of one or more key-values items which store additional message information. Each item consists of a key and the values in an array. Items are saved and will be returned in the exact order they've been specified.")
   @JsonProperty(JSON_PROPERTY_SORTED_METAARRAY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -176,7 +176,7 @@ public class UpdateExtraDataInMessageData {
    * Determines whether to add the specified values in the items or remove the specified values from the existing items. Acceptable values are limited to add and remove. If set to add, the specified values are added only when they are different from the existing values. If set to remove, the specified values are removed only when they have the corresponding ones in the existing values.
    * @return mode
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to add the specified values in the items or remove the specified values from the existing items. Acceptable values are limited to add and remove. If set to add, the specified values are added only when they are different from the existing values. If set to remove, the specified values are removed only when they have the corresponding ones in the existing values.")
   @JsonProperty(JSON_PROPERTY_MODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -202,7 +202,7 @@ public class UpdateExtraDataInMessageData {
    * Determines whether to add new items in addition to updating existing items. If true, new key-values items are added when there are no items with the keys. The existing items are updated with new values when there are already items with the keys. If false, only the items of which keys match the ones you specify are updated with new values. (Default: false)
    * @return upsert
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to add new items in addition to updating existing items. If true, new key-values items are added when there are no items with the keys. The existing items are updated with new values when there are already items with the keys. If false, only the items of which keys match the ones you specify are updated with new values. (Default: false)")
   @JsonProperty(JSON_PROPERTY_UPSERT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   UpdateExtraDataInMessageResponse.JSON_PROPERTY_SORTED_METAARRAY
 })
 @JsonTypeName("updateExtraDataInMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateExtraDataInMessageResponse {
   public static final String JSON_PROPERTY_SORTED_METAARRAY = "sorted_metaarray";
   private List<UpdateExtraDataInMessageResponseSortedMetaarrayInner> sortedMetaarray = null;
@@ -63,7 +63,7 @@ public class UpdateExtraDataInMessageResponse {
    * Get sortedMetaarray
    * @return sortedMetaarray
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SORTED_METAARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageResponseSortedMetaarrayInner.java
+++ b/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageResponseSortedMetaarrayInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   UpdateExtraDataInMessageResponseSortedMetaarrayInner.JSON_PROPERTY_KEY
 })
 @JsonTypeName("updateExtraDataInMessageResponse_sorted_metaarray_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateExtraDataInMessageResponseSortedMetaarrayInner {
   public static final String JSON_PROPERTY_VALUE = "value";
   private List<String> value = null;
@@ -66,7 +66,7 @@ public class UpdateExtraDataInMessageResponseSortedMetaarrayInner {
    * Get value
    * @return value
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VALUE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class UpdateExtraDataInMessageResponseSortedMetaarrayInner {
    * Get key
    * @return key
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateFcmPushConfigurationByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateFcmPushConfigurationByIdData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   UpdateFcmPushConfigurationByIdData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("updateFcmPushConfigurationByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateFcmPushConfigurationByIdData {
   public static final String JSON_PROPERTY_PROVIDER_ID = "provider_id";
   private String providerId;
@@ -60,7 +60,7 @@ public class UpdateFcmPushConfigurationByIdData {
    * Specifies the provider ID of the push configuration to update.
    * @return providerId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the provider ID of the push configuration to update.")
   @JsonProperty(JSON_PROPERTY_PROVIDER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class UpdateFcmPushConfigurationByIdData {
    * Specifies the FCM server key to update.
    * @return apiKey
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the FCM server key to update.")
   @JsonProperty(JSON_PROPERTY_API_KEY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class UpdateFcmPushConfigurationByIdData {
    * Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file should be located in the &#x60;/res/raw&#x60; folder.
    * @return pushSound
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file should be located in the `/res/raw` folder.")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateFcmPushConfigurationByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateFcmPushConfigurationByIdResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateFcmPushConfigurationByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("updateFcmPushConfigurationByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateFcmPushConfigurationByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private String pushConfigurations;
@@ -52,7 +52,7 @@ public class UpdateFcmPushConfigurationByIdResponse {
    * Get pushConfigurations
    * @return pushConfigurations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_CONFIGURATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateHmsPushConfigurationByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateHmsPushConfigurationByIdData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   UpdateHmsPushConfigurationByIdData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("updateHmsPushConfigurationByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateHmsPushConfigurationByIdData {
   public static final String JSON_PROPERTY_PROVIDER_ID = "provider_id";
   private String providerId;
@@ -64,7 +64,7 @@ public class UpdateHmsPushConfigurationByIdData {
    * Specifies the provider ID of the push configuration to update.
    * @return providerId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the provider ID of the push configuration to update.")
   @JsonProperty(JSON_PROPERTY_PROVIDER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -90,7 +90,7 @@ public class UpdateHmsPushConfigurationByIdData {
    * Specifies the unique ID of application for HMS to update.
    * @return huaweiAppId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of application for HMS to update.")
   @JsonProperty(JSON_PROPERTY_HUAWEI_APP_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -116,7 +116,7 @@ public class UpdateHmsPushConfigurationByIdData {
    * Specifies the secret key of the application to update.
    * @return huaweiAppSecret
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the secret key of the application to update.")
   @JsonProperty(JSON_PROPERTY_HUAWEI_APP_SECRET)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -142,7 +142,7 @@ public class UpdateHmsPushConfigurationByIdData {
    * Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file should be located in the &#x60;/res/raw&#x60; folder.
    * @return pushSound
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the name of a sound file to be played when a push notification is delivered to your client app. The file should be located in the `/res/raw` folder.")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateHmsPushConfigurationByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateHmsPushConfigurationByIdResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateHmsPushConfigurationByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("updateHmsPushConfigurationByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateHmsPushConfigurationByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private String pushConfigurations;
@@ -52,7 +52,7 @@ public class UpdateHmsPushConfigurationByIdResponse {
    * Get pushConfigurations
    * @return pushConfigurations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_CONFIGURATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateMessageByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateMessageByIdData.java
@@ -45,7 +45,7 @@ import org.sendbird.client.JSON;
   UpdateMessageByIdData.JSON_PROPERTY_MENTIONED_USER_IDS
 })
 @JsonTypeName("updateMessageByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateMessageByIdData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;
@@ -86,7 +86,7 @@ public class UpdateMessageByIdData {
    * Specifies the type of the channel. Either open_channels or group_channels.
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the type of the channel. Either open_channels or group_channels.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -112,7 +112,7 @@ public class UpdateMessageByIdData {
    * Specifies the URL of the target channel.
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the target channel.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -138,7 +138,7 @@ public class UpdateMessageByIdData {
    * Specifies the unique ID of the message to update.
    * @return messageId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the message to update.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -164,7 +164,7 @@ public class UpdateMessageByIdData {
    * Specifies the type of the message as ADMM.
    * @return messageType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the type of the message as ADMM.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -190,7 +190,7 @@ public class UpdateMessageByIdData {
    * Specifies the content of the message.
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the content of the message.")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -216,7 +216,7 @@ public class UpdateMessageByIdData {
    * Specifies a custom message type which is used for message grouping. The length is limited to 128 characters.&lt;br /&gt;&lt;br /&gt; Custom types are also used within Sendbird&#39;s [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies a custom message type which is used for message grouping. The length is limited to 128 characters.<br /><br /> Custom types are also used within Sendbird's [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -242,7 +242,7 @@ public class UpdateMessageByIdData {
    * Specifies additional message information such as custom font size, font type or &#x60;JSON&#x60; formatted string.
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional message information such as custom font size, font type or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -268,7 +268,7 @@ public class UpdateMessageByIdData {
    * Specifies the mentioning method which indicates the user scope who will get a notification for the message. Acceptable values are users and channel. If set to users, only the specified users with the mentioned_users property below will get notified. If set to channel, all users in the channel will get notified. (Default: users)
    * @return mentionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the mentioning method which indicates the user scope who will get a notification for the message. Acceptable values are users and channel. If set to users, only the specified users with the mentioned_users property below will get notified. If set to channel, all users in the channel will get notified. (Default: users)")
   @JsonProperty(JSON_PROPERTY_MENTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -302,7 +302,7 @@ public class UpdateMessageByIdData {
    * Specifies an array of one or more IDs of the users who will get a notification for the message.
    * @return mentionedUserIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more IDs of the users who will get a notification for the message.")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdatePushNotificationContentTemplateData.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushNotificationContentTemplateData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   UpdatePushNotificationContentTemplateData.JSON_PROPERTY_TEMPLATE_A_D_M_N
 })
 @JsonTypeName("updatePushNotificationContentTemplateData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdatePushNotificationContentTemplateData {
   public static final String JSON_PROPERTY_TEMPLATE_NAME = "template_name";
   private String templateName;
@@ -68,7 +68,7 @@ public class UpdatePushNotificationContentTemplateData {
    * Specifies the name of a push notification content template to update. Acceptable values are default and alternative.
    * @return templateName
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the name of a push notification content template to update. Acceptable values are default and alternative.")
   @JsonProperty(JSON_PROPERTY_TEMPLATE_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -94,7 +94,7 @@ public class UpdatePushNotificationContentTemplateData {
    * The push notification content template of which content types to be updated and their detailed format.
    * @return template
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "The push notification content template of which content types to be updated and their detailed format.")
   @JsonProperty(JSON_PROPERTY_TEMPLATE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -120,7 +120,7 @@ public class UpdatePushNotificationContentTemplateData {
    * Specifies a format for text messages. We support customization of two fields, which are the sender_name and message. These fields will be replaced with actual corresponding values when sending notification requests to FCM, HMS, or APNs.
    * @return templateMESG
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a format for text messages. We support customization of two fields, which are the sender_name and message. These fields will be replaced with actual corresponding values when sending notification requests to FCM, HMS, or APNs.")
   @JsonProperty(JSON_PROPERTY_TEMPLATE_M_E_S_G)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -146,7 +146,7 @@ public class UpdatePushNotificationContentTemplateData {
    * Specifies a format for file messages. We support customization with variables including filename and file_type_friendly. When sending notification requests to FCM, HMS, or APNs, the filename will be replaced with the corresponding string value while the file_type_friendly will indicate the type of the file sent, such as &#x60;Audio&#x60;, &#x60;Image&#x60;, and &#x60;Video&#x60;.
    * @return templateFILE
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a format for file messages. We support customization with variables including filename and file_type_friendly. When sending notification requests to FCM, HMS, or APNs, the filename will be replaced with the corresponding string value while the file_type_friendly will indicate the type of the file sent, such as `Audio`, `Image`, and `Video`.")
   @JsonProperty(JSON_PROPERTY_TEMPLATE_F_I_L_E)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -172,7 +172,7 @@ public class UpdatePushNotificationContentTemplateData {
    * Specifies a format for admin messages. We support customization of one field, which is the message. This field will be replaced with actual corresponding values when sending notification requests to FCM, HMS, or APNs.
    * @return templateADMN
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a format for admin messages. We support customization of one field, which is the message. This field will be replaced with actual corresponding values when sending notification requests to FCM, HMS, or APNs.")
   @JsonProperty(JSON_PROPERTY_TEMPLATE_A_D_M_N)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdatePushNotificationContentTemplateResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushNotificationContentTemplateResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   UpdatePushNotificationContentTemplateResponse.JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES
 })
 @JsonTypeName("updatePushNotificationContentTemplateResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdatePushNotificationContentTemplateResponse {
   public static final String JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES = "push_message_templates";
   private List<ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner> pushMessageTemplates = null;
@@ -63,7 +63,7 @@ public class UpdatePushNotificationContentTemplateResponse {
    * Get pushMessageTemplates
    * @return pushMessageTemplates
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdatePushPreferencesData.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushPreferencesData.java
@@ -49,7 +49,7 @@ import org.sendbird.client.JSON;
   UpdatePushPreferencesData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("updatePushPreferencesData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdatePushPreferencesData {
   public static final String JSON_PROPERTY_PUSH_TRIGGER_OPTION = "push_trigger_option";
   private String pushTriggerOption;
@@ -102,7 +102,7 @@ public class UpdatePushPreferencesData {
    * Determines the type of push notification trigger to apply to the user&#39;s joined group channels. Valid values are the following:&lt;br /&gt;- all (default): when disconnected from Sendbird server, the user receives notifications for all new messages including mentioned messages the user has been mentioned in.&lt;br /&gt;- mention_only: when disconnected from Sendbird server, the user only receives notifications for messages the user has been mentioned in.&lt;br /&gt;- off: the user doesn&#39;t receive any notifications.
    * @return pushTriggerOption
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines the type of push notification trigger to apply to the user's joined group channels. Valid values are the following:<br />- all (default): when disconnected from Sendbird server, the user receives notifications for all new messages including mentioned messages the user has been mentioned in.<br />- mention_only: when disconnected from Sendbird server, the user only receives notifications for messages the user has been mentioned in.<br />- off: the user doesn't receive any notifications.")
   @JsonProperty(JSON_PROPERTY_PUSH_TRIGGER_OPTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -128,7 +128,7 @@ public class UpdatePushPreferencesData {
    * Determines whether to pause notification messages for the user during a specific time of day. (Default: false)
    * @return doNotDisturb
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to pause notification messages for the user during a specific time of day. (Default: false)")
   @JsonProperty(JSON_PROPERTY_DO_NOT_DISTURB)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -154,7 +154,7 @@ public class UpdatePushPreferencesData {
    * Specifies the hour to start pausing the notifications for Do Not Disturb of the user.
    * @return startHour
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the hour to start pausing the notifications for Do Not Disturb of the user.")
   @JsonProperty(JSON_PROPERTY_START_HOUR)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -180,7 +180,7 @@ public class UpdatePushPreferencesData {
    * Specifies the minute of the hour to start pausing the notifications for Do Not Disturb of the user.
    * @return startMin
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the minute of the hour to start pausing the notifications for Do Not Disturb of the user.")
   @JsonProperty(JSON_PROPERTY_START_MIN)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -206,7 +206,7 @@ public class UpdatePushPreferencesData {
    * Specifies the hour to stop pausing the notifications for Do Not Disturb of the user.
    * @return endHour
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the hour to stop pausing the notifications for Do Not Disturb of the user.")
   @JsonProperty(JSON_PROPERTY_END_HOUR)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -232,7 +232,7 @@ public class UpdatePushPreferencesData {
    * Specifies the minute of the hour to stop pausing the notifications for Do Not Disturb of the user.
    * @return endMin
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the minute of the hour to stop pausing the notifications for Do Not Disturb of the user.")
   @JsonProperty(JSON_PROPERTY_END_MIN)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -258,7 +258,7 @@ public class UpdatePushPreferencesData {
    * Determines whether to snooze notification messages for the user during a specific period of time. (Default: false)
    * @return snoozeEnabled
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to snooze notification messages for the user during a specific period of time. (Default: false)")
   @JsonProperty(JSON_PROPERTY_SNOOZE_ENABLED)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -284,7 +284,7 @@ public class UpdatePushPreferencesData {
    * Specifies the timestamp of when to start snoozing the notifications, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps).
    * @return snoozeStartTs
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the timestamp of when to start snoozing the notifications, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps).")
   @JsonProperty(JSON_PROPERTY_SNOOZE_START_TS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -310,7 +310,7 @@ public class UpdatePushPreferencesData {
    * Specifies the timestamp of when to end snoozing the notifications, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps).
    * @return snoozeEndTs
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the timestamp of when to end snoozing the notifications, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps).")
   @JsonProperty(JSON_PROPERTY_SNOOZE_END_TS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -336,7 +336,7 @@ public class UpdatePushPreferencesData {
    * Determines whether to block push notifications from [all bots](/docs/chat/v3/platform-api/guides/bot-interface#2-list-bots) within the application. If the push_blocked_bot_ids is specified, notifications only from the bots in the property are blocked. (Default: false)
    * @return blockPushFromBots
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to block push notifications from [all bots](/docs/chat/v3/platform-api/guides/bot-interface#2-list-bots) within the application. If the push_blocked_bot_ids is specified, notifications only from the bots in the property are blocked. (Default: false)")
   @JsonProperty(JSON_PROPERTY_BLOCK_PUSH_FROM_BOTS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -367,7 +367,7 @@ public class UpdatePushPreferencesData {
    * Specifies an array of one or more IDs of bots whose push notifications are blocked. This property is effective only when the block_push_from_bots is set to true.
    * @return pushBlockedBotIds
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies an array of one or more IDs of bots whose push notifications are blocked. This property is effective only when the block_push_from_bots is set to true.")
   @JsonProperty(JSON_PROPERTY_PUSH_BLOCKED_BOT_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -393,7 +393,7 @@ public class UpdatePushPreferencesData {
    * Specifies the timezone to be applied to push preferences with a value such as UTC, Asia/Seoul, Europe/London, etc.
    * @return timezone
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the timezone to be applied to push preferences with a value such as UTC, Asia/Seoul, Europe/London, etc.")
   @JsonProperty(JSON_PROPERTY_TIMEZONE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -419,7 +419,7 @@ public class UpdatePushPreferencesData {
    * Specifies the name of a sound file to be played when a push notification is delivered to your client app.
    * @return pushSound
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the name of a sound file to be played when a push notification is delivered to your client app.")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdatePushPreferencesForChannelByUrlData.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushPreferencesForChannelByUrlData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   UpdatePushPreferencesForChannelByUrlData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("updatePushPreferencesForChannelByUrlData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdatePushPreferencesForChannelByUrlData {
   public static final String JSON_PROPERTY_PUSH_TRIGGER_OPTION = "push_trigger_option";
   private String pushTriggerOption;
@@ -60,7 +60,7 @@ public class UpdatePushPreferencesForChannelByUrlData {
    * Determines the type of push notification trigger to apply to the speficied channel. Acceptable values are limited to the following:&lt;br /&gt;- default: the user&#39;s push notification trigger setting automatically applies to the channel. This is the default setting.&lt;br /&gt;- all: when disconnected from Sendbird server, the user receives notifications for all new messages in the channel including messages the user has been mentioned in.&lt;br /&gt;- mention_only: when disconnected from Sendbird server, the user only receives notifications for messages in the channel the user has been mentioned in.&lt;br /&gt;- off: the user doesn&#39;t receive any notifications in the channel.
    * @return pushTriggerOption
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines the type of push notification trigger to apply to the speficied channel. Acceptable values are limited to the following:<br />- default: the user's push notification trigger setting automatically applies to the channel. This is the default setting.<br />- all: when disconnected from Sendbird server, the user receives notifications for all new messages in the channel including messages the user has been mentioned in.<br />- mention_only: when disconnected from Sendbird server, the user only receives notifications for messages in the channel the user has been mentioned in.<br />- off: the user doesn't receive any notifications in the channel.")
   @JsonProperty(JSON_PROPERTY_PUSH_TRIGGER_OPTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -86,7 +86,7 @@ public class UpdatePushPreferencesForChannelByUrlData {
    * (Deprecated) Determines whether notification messages for the user are delivered to the group channel. (default: true)
    * @return enable
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "(Deprecated) Determines whether notification messages for the user are delivered to the group channel. (default: true)")
   @JsonProperty(JSON_PROPERTY_ENABLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -112,7 +112,7 @@ public class UpdatePushPreferencesForChannelByUrlData {
    * Specifies the name of a sound file to be played when a push notification is delivered to the specified channel.
    * @return pushSound
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the name of a sound file to be played when a push notification is delivered to the specified channel.")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdatePushPreferencesForChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushPreferencesForChannelByUrlResponse.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   UpdatePushPreferencesForChannelByUrlResponse.JSON_PROPERTY_ENABLE
 })
 @JsonTypeName("updatePushPreferencesForChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdatePushPreferencesForChannelByUrlResponse {
   public static final String JSON_PROPERTY_PUSH_TRIGGER_OPTION = "push_trigger_option";
   private String pushTriggerOption;
@@ -97,7 +97,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get pushTriggerOption
    * @return pushTriggerOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_TRIGGER_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -123,7 +123,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get doNotDisturb
    * @return doNotDisturb
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DO_NOT_DISTURB)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -149,7 +149,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get startHour
    * @return startHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -175,7 +175,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get startMin
    * @return startMin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -201,7 +201,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get endHour
    * @return endHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -227,7 +227,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get endMin
    * @return endMin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -253,7 +253,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get snoozeEnabled
    * @return snoozeEnabled
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -279,7 +279,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get snoozeStartTs
    * @return snoozeStartTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_START_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -305,7 +305,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get snoozeEndTs
    * @return snoozeEndTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_END_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -331,7 +331,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get timezone
    * @return timezone
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TIMEZONE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -357,7 +357,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get pushSound
    * @return pushSound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -383,7 +383,7 @@ public class UpdatePushPreferencesForChannelByUrlResponse {
    * Get enable
    * @return enable
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdatePushPreferencesResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushPreferencesResponse.java
@@ -51,7 +51,7 @@ import org.sendbird.client.JSON;
   UpdatePushPreferencesResponse.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("updatePushPreferencesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdatePushPreferencesResponse {
   public static final String JSON_PROPERTY_BLOCK_PUSH_FROM_BOTS = "block_push_from_bots";
   private Boolean blockPushFromBots;
@@ -107,7 +107,7 @@ public class UpdatePushPreferencesResponse {
    * Get blockPushFromBots
    * @return blockPushFromBots
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BLOCK_PUSH_FROM_BOTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -133,7 +133,7 @@ public class UpdatePushPreferencesResponse {
    * Get enablePushForReplies
    * @return enablePushForReplies
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_PUSH_FOR_REPLIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -167,7 +167,7 @@ public class UpdatePushPreferencesResponse {
    * Get pushBlockedBotIds
    * @return pushBlockedBotIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_BLOCKED_BOT_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -193,7 +193,7 @@ public class UpdatePushPreferencesResponse {
    * Get pushTriggerOption
    * @return pushTriggerOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_TRIGGER_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -219,7 +219,7 @@ public class UpdatePushPreferencesResponse {
    * Get doNotDisturb
    * @return doNotDisturb
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DO_NOT_DISTURB)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -245,7 +245,7 @@ public class UpdatePushPreferencesResponse {
    * Get startHour
    * @return startHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -271,7 +271,7 @@ public class UpdatePushPreferencesResponse {
    * Get startMin
    * @return startMin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -297,7 +297,7 @@ public class UpdatePushPreferencesResponse {
    * Get endHour
    * @return endHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -323,7 +323,7 @@ public class UpdatePushPreferencesResponse {
    * Get endMin
    * @return endMin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -349,7 +349,7 @@ public class UpdatePushPreferencesResponse {
    * Get snoozeEnabled
    * @return snoozeEnabled
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -375,7 +375,7 @@ public class UpdatePushPreferencesResponse {
    * Get snoozeStartTs
    * @return snoozeStartTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_START_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -401,7 +401,7 @@ public class UpdatePushPreferencesResponse {
    * Get snoozeEndTs
    * @return snoozeEndTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_END_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -427,7 +427,7 @@ public class UpdatePushPreferencesResponse {
    * Get timezone
    * @return timezone
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TIMEZONE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -453,7 +453,7 @@ public class UpdatePushPreferencesResponse {
    * Get pushSound
    * @return pushSound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateUserByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateUserByIdData.java
@@ -49,7 +49,7 @@ import org.sendbird.client.JSON;
   UpdateUserByIdData.JSON_PROPERTY_LEAVE_ALL_WHEN_DEACTIVATED
 })
 @JsonTypeName("updateUserByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateUserByIdData {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -99,7 +99,7 @@ public class UpdateUserByIdData {
    * Specifies the unique ID of the user to update.
    * @return userId
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the unique ID of the user to update.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -125,7 +125,7 @@ public class UpdateUserByIdData {
    * Specifies the user&#39;s nickname. The length is limited to 80 characters.
    * @return nickname
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the user's nickname. The length is limited to 80 characters.")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -151,7 +151,7 @@ public class UpdateUserByIdData {
    * Specifies the URL of the user&#39;s profile image. The length is limited to 2,048 characters.&lt;br /&gt;&lt;br /&gt; The [domain filter](/docs/chat/v3/platform-api/guides/filter-and-moderation#2-domain-filter) filters out the request if the value of this property matches the filter&#39;s domain set.
    * @return profileUrl
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies the URL of the user's profile image. The length is limited to 2,048 characters.<br /><br /> The [domain filter](/docs/chat/v3/platform-api/guides/filter-and-moderation#2-domain-filter) filters out the request if the value of this property matches the filter's domain set.")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -177,7 +177,7 @@ public class UpdateUserByIdData {
    * Uploads the file of the user&#39;s profile image. An acceptable image is limited to &#x60;JPG&#x60; (.jpg), &#x60;JPEG&#x60; (.jpeg), or &#x60;PNG&#x60; (.png) file of up to 25 MB.
    * @return profileFile
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Uploads the file of the user's profile image. An acceptable image is limited to `JPG` (.jpg), `JPEG` (.jpeg), or `PNG` (.png) file of up to 25 MB.")
   @JsonProperty(JSON_PROPERTY_PROFILE_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -203,7 +203,7 @@ public class UpdateUserByIdData {
    * Determines whether to revoke the existing access token and create a new one for the user. If true, an opaque string token is issued and provided upon creation, which should be passed whenever the user logs in. If false, an access token is not required when the user logs in. (Default: false)
    * @return issueAccessToken
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to revoke the existing access token and create a new one for the user. If true, an opaque string token is issued and provided upon creation, which should be passed whenever the user logs in. If false, an access token is not required when the user logs in. (Default: false)")
   @JsonProperty(JSON_PROPERTY_ISSUE_ACCESS_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -229,7 +229,7 @@ public class UpdateUserByIdData {
    * Determines whether to add a new session token for the user. If true, an opaque string token is issued and provided upon creation, which should be passed whenever the user logs in. If false, a session token is not required when the user logs in. (Default: false)
    * @return issueSessionToken
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to add a new session token for the user. If true, an opaque string token is issued and provided upon creation, which should be passed whenever the user logs in. If false, a session token is not required when the user logs in. (Default: false)")
   @JsonProperty(JSON_PROPERTY_ISSUE_SESSION_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -255,7 +255,7 @@ public class UpdateUserByIdData {
    * Specifies the time for the issued session token to expire in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. The length should be 13. If not specified and the issue_session_token property above is true, the value of this property is set to the sum of the current timestamp and 604800000 by default, which indicates that the token will be valid for the next 7 days starting from the current timestamp.
    * @return sessionTokenExpiresAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time for the issued session token to expire in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format. The length should be 13. If not specified and the issue_session_token property above is true, the value of this property is set to the sum of the current timestamp and 604800000 by default, which indicates that the token will be valid for the next 7 days starting from the current timestamp.")
   @JsonProperty(JSON_PROPERTY_SESSION_TOKEN_EXPIRES_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -281,7 +281,7 @@ public class UpdateUserByIdData {
    * Determines whether to activate or deactivate the user within the application.
    * @return isActive
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to activate or deactivate the user within the application.")
   @JsonProperty(JSON_PROPERTY_IS_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -307,7 +307,7 @@ public class UpdateUserByIdData {
    * Specifies the time when the user goes offline, to indicate when they were last online, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format.
    * @return lastSeenAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the time when the user goes offline, to indicate when they were last online, in [Unix milliseconds](/docs/chat/v3/platform-api/guides/miscellaneous#2-timestamps) format.")
   @JsonProperty(JSON_PROPERTY_LAST_SEEN_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -341,7 +341,7 @@ public class UpdateUserByIdData {
    * Specifies an array of unique keys of the user which is provided to Sendbird server for discovering friends. By using the keys, the server can identify and match the user with other users.
    * @return discoveryKeys
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of unique keys of the user which is provided to Sendbird server for discovering friends. By using the keys, the server can identify and match the user with other users.")
   @JsonProperty(JSON_PROPERTY_DISCOVERY_KEYS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -375,7 +375,7 @@ public class UpdateUserByIdData {
    * Specifies an array of one or more [language codes](/docs/chat/v3/platform-api/guides/miscellaneous#2-language-codes-for-auto-translation) to translate notification messages to preferred languages. Up to 4 languages can be set for the user. If messages are sent in one of the preferred languages, notification messages won&#39;t be translated. If messages are sent in a language other than the preferred languages, notification messages will be translated into the first language in the array. In addition, the messages translated into other preferred languages will be provided in the &#x60;sendbird&#x60; property of a notification message payload.
    * @return preferredLanguages
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more [language codes](/docs/chat/v3/platform-api/guides/miscellaneous#2-language-codes-for-auto-translation) to translate notification messages to preferred languages. Up to 4 languages can be set for the user. If messages are sent in one of the preferred languages, notification messages won't be translated. If messages are sent in a language other than the preferred languages, notification messages will be translated into the first language in the array. In addition, the messages translated into other preferred languages will be provided in the `sendbird` property of a notification message payload.")
   @JsonProperty(JSON_PROPERTY_PREFERRED_LANGUAGES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -401,7 +401,7 @@ public class UpdateUserByIdData {
    * Determines whether the user leaves all joined group channels upon deactivation. Note that this value is true by default. Use in conjunction with the is_active property above.
    * @return leaveAllWhenDeactivated
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether the user leaves all joined group channels upon deactivation. Note that this value is true by default. Use in conjunction with the is_active property above.")
   @JsonProperty(JSON_PROPERTY_LEAVE_ALL_WHEN_DEACTIVATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UpdateUserMetadataData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateUserMetadataData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   UpdateUserMetadataData.JSON_PROPERTY_UPSERT
 })
 @JsonTypeName("updateUserMetadataData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateUserMetadataData {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   private Object metadata;
@@ -56,7 +56,7 @@ public class UpdateUserMetadataData {
    * Specifies a &#x60;JSON&#x60; object that stores key-value items. The key must not have a comma (,) and its length is limited to 128 characters. The value must be a string and its length is limited to 190 characters. This property can have up to 5 items.
    * @return metadata
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Specifies a `JSON` object that stores key-value items. The key must not have a comma (,) and its length is limited to 128 characters. The value must be a string and its length is limited to 190 characters. This property can have up to 5 items.")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
@@ -82,7 +82,7 @@ public class UpdateUserMetadataData {
    * Get upsert
    * @return upsert
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "")
   @JsonProperty(JSON_PROPERTY_UPSERT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UpdateUserMetadataResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateUserMetadataResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   UpdateUserMetadataResponse.JSON_PROPERTY_UPSERT
 })
 @JsonTypeName("updateUserMetadataResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UpdateUserMetadataResponse {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   private Map<String, String> metadata = null;
@@ -67,7 +67,7 @@ public class UpdateUserMetadataResponse {
    * Get metadata
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class UpdateUserMetadataResponse {
    * Get upsert
    * @return upsert
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UPSERT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/UseDefaultEmojisData.java
+++ b/src/main/java/org/openapitools/client/model/UseDefaultEmojisData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UseDefaultEmojisData.JSON_PROPERTY_USE_DEFAULT_EMOJI
 })
 @JsonTypeName("useDefaultEmojisData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UseDefaultEmojisData {
   public static final String JSON_PROPERTY_USE_DEFAULT_EMOJI = "use_default_emoji";
   private Boolean useDefaultEmoji;
@@ -52,7 +52,7 @@ public class UseDefaultEmojisData {
    * Determines whether to use the 7 default emojis initially provided.
    * @return useDefaultEmoji
   **/
-  @javax.annotation.Nonnull
+  @jakarta.annotation.Nonnull
   @ApiModelProperty(required = true, value = "Determines whether to use the 7 default emojis initially provided.")
   @JsonProperty(JSON_PROPERTY_USE_DEFAULT_EMOJI)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)

--- a/src/main/java/org/openapitools/client/model/UseDefaultEmojisResponse.java
+++ b/src/main/java/org/openapitools/client/model/UseDefaultEmojisResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UseDefaultEmojisResponse.JSON_PROPERTY_USE_DEFAULT_EMOJI
 })
 @JsonTypeName("useDefaultEmojisResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UseDefaultEmojisResponse {
   public static final String JSON_PROPERTY_USE_DEFAULT_EMOJI = "use_default_emoji";
   private Boolean useDefaultEmoji;
@@ -52,7 +52,7 @@ public class UseDefaultEmojisResponse {
    * Get useDefaultEmoji
    * @return useDefaultEmoji
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USE_DEFAULT_EMOJI)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3ApplicationsPushSettingsGet200Response.java
+++ b/src/main/java/org/openapitools/client/model/V3ApplicationsPushSettingsGet200Response.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   V3ApplicationsPushSettingsGet200Response.JSON_PROPERTY_PUSH_ENABLED
 })
 @JsonTypeName("_v3_applications_push_settings_get_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3ApplicationsPushSettingsGet200Response {
   public static final String JSON_PROPERTY_PUSH_ENABLED = "push_enabled";
   private Boolean pushEnabled;
@@ -52,7 +52,7 @@ public class V3ApplicationsPushSettingsGet200Response {
    * Get pushEnabled
    * @return pushEnabled
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3ApplicationsPushSettingsGetRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3ApplicationsPushSettingsGetRequest.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   V3ApplicationsPushSettingsGetRequest.JSON_PROPERTY_PUSH_ENABLED
 })
 @JsonTypeName("_v3_applications_push_settings_get_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3ApplicationsPushSettingsGetRequest {
   public static final String JSON_PROPERTY_PUSH_ENABLED = "push_enabled";
   private Boolean pushEnabled;
@@ -52,7 +52,7 @@ public class V3ApplicationsPushSettingsGetRequest {
    * Determines whether to turn on the push notifications feature for an application.
    * @return pushEnabled
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to turn on the push notifications feature for an application.")
   @JsonProperty(JSON_PROPERTY_PUSH_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteRequest.java
@@ -56,7 +56,7 @@ import org.sendbird.client.JSON;
   V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteRequest.JSON_PROPERTY_VOLUME
 })
 @JsonTypeName("_v3_group_channels__channel_url__scheduled_messages__scheduled_message_id__delete_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteRequest {
   public static final String JSON_PROPERTY_MESSAGE_TYPE = "message_type";
   private String messageType;
@@ -127,7 +127,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies the type of the message. The value of MESG represents a text message.
    * @return messageType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the type of the message. The value of MESG represents a text message.")
   @JsonProperty(JSON_PROPERTY_MESSAGE_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -153,7 +153,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies the user ID of the sender.
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the user ID of the sender.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -179,7 +179,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies the content of the message.
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the content of the message.")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -205,7 +205,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Depending on the file upload method, this specifies the data of the file to upload to the Sendbird server either in raw binary format or by the file&#39;s location. When sending a request containing a file, you must change the value of the content-type header to multipart/form-data; boundary&#x3D;{your_unique_boundary_string} in the request. The code examples of HTTP multipart request and cURL are provided below the tables for your reference. If this file property is specified, the url property is not required. This doesn&#39;t allow a converted base64-encoded string from a file as its value.
    * @return _file
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Depending on the file upload method, this specifies the data of the file to upload to the Sendbird server either in raw binary format or by the file's location. When sending a request containing a file, you must change the value of the content-type header to multipart/form-data; boundary={your_unique_boundary_string} in the request. The code examples of HTTP multipart request and cURL are provided below the tables for your reference. If this file property is specified, the url property is not required. This doesn't allow a converted base64-encoded string from a file as its value.")
   @JsonProperty(JSON_PROPERTY_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -231,7 +231,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies the URL of the file hosted on the server of your own or other third-party companies. If this url property is specified, the file property is not required.
    * @return url
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the file hosted on the server of your own or other third-party companies. If this url property is specified, the file property is not required.")
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -257,7 +257,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * The specified time that indicates when to send the message, in Unix milliseconds format. Since messages are scheduled in minutes, values less than seconds are discarded. The specified time can be between 5 minutes and 43,200 minutes (30 days) from the current time.
    * @return scheduledAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "The specified time that indicates when to send the message, in Unix milliseconds format. Since messages are scheduled in minutes, values less than seconds are discarded. The specified time can be between 5 minutes and 43,200 minutes (30 days) from the current time.")
   @JsonProperty(JSON_PROPERTY_SCHEDULED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -283,7 +283,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies a custom message type used for message grouping. The length is limited to 128 characters. * Custom types are also used to segment metrics within Sendbird&#39;s Advanced analytics, which enables the sub-classification of data views.
    * @return customType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies a custom message type used for message grouping. The length is limited to 128 characters. * Custom types are also used to segment metrics within Sendbird's Advanced analytics, which enables the sub-classification of data views.")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -309,7 +309,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies additional message information such as custom font size, font type, or JSON formatted string.
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies additional message information such as custom font size, font type, or JSON formatted string.")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -335,7 +335,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Determines whether to send a push notification of the message to the channel members. This property only applies to group channels. (Default is true)
    * @return sendPush
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to send a push notification of the message to the channel members. This property only applies to group channels. (Default is true)")
   @JsonProperty(JSON_PROPERTY_SEND_PUSH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -361,7 +361,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies the mentioning method that indicates which user receives a notification of the message. Acceptable values are users and channels. If set to users, only the users specified in the mentioned_user_ids property below are notified. If set to channels, all users in the channel are notified. (Default &#x3D; users)
    * @return mentionType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the mentioning method that indicates which user receives a notification of the message. Acceptable values are users and channels. If set to users, only the users specified in the mentioned_user_ids property below are notified. If set to channels, all users in the channel are notified. (Default = users)")
   @JsonProperty(JSON_PROPERTY_MENTION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -395,7 +395,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies an array of one or more IDs of the users who will receive a notification of the message.
    * @return mentionedUserIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more IDs of the users who will receive a notification of the message.")
   @JsonProperty(JSON_PROPERTY_MENTIONED_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -421,7 +421,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Determines whether to send a message without updating some of the following channel properties. If set to true, the channel&#39;s last_message is updated only for the sender while its unread_message_count remains unchanged for all channel members. Also, a push notification isn&#39;t sent to the users receiving the message. If the message is sent to a hidden channel, the channel remains hidden. (Default is false)
    * @return isSilent
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to send a message without updating some of the following channel properties. If set to true, the channel's last_message is updated only for the sender while its unread_message_count remains unchanged for all channel members. Also, a push notification isn't sent to the users receiving the message. If the message is sent to a hidden channel, the channel remains hidden. (Default is false)")
   @JsonProperty(JSON_PROPERTY_IS_SILENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -447,7 +447,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Determines whether to mark the message as read for the sender. If set to false, then the sender&#39;s unread_count and read_receipt remain unchanged after the message is sent. (Default is true)
    * @return markAsRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to mark the message as read for the sender. If set to false, then the sender's unread_count and read_receipt remain unchanged after the message is sent. (Default is true)")
   @JsonProperty(JSON_PROPERTY_MARK_AS_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -481,7 +481,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies an array of one or more JSON objects consisting of key-values items that store additional message information. Items are saved and returned in the exact order they&#39;ve been specified.
    * @return sortedMetaarray
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of one or more JSON objects consisting of key-values items that store additional message information. Items are saved and returned in the exact order they've been specified.")
   @JsonProperty(JSON_PROPERTY_SORTED_METAARRAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -507,7 +507,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies a unique ID for the message created by another system. In general, this property is used to prevent the same message data from getting inserted when migrating messages from another system to the Sendbird server. If specified, the server performs a duplicate check using the property value.
    * @return dedupId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies a unique ID for the message created by another system. In general, this property is used to prevent the same message data from getting inserted when migrating messages from another system to the Sendbird server. If specified, the server performs a duplicate check using the property value.")
   @JsonProperty(JSON_PROPERTY_DEDUP_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -533,7 +533,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies the bundle ID of the client app in order to send a push notification to iOS devices. You can find this in Settings &gt; Chat &gt; Notifications &gt; Push notification services on Sendbird Dashboard.
    * @return apnsBundleId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the bundle ID of the client app in order to send a push notification to iOS devices. You can find this in Settings > Chat > Notifications > Push notification services on Sendbird Dashboard.")
   @JsonProperty(JSON_PROPERTY_APNS_BUNDLE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -559,7 +559,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies options that support Apple&#39;s critical alerts and checks whether the message is a critical alert.
    * @return appleCriticalAlertOptions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies options that support Apple's critical alerts and checks whether the message is a critical alert.")
   @JsonProperty(JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -585,7 +585,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies the name of a sound file that is used for critical alerts.
    * @return sound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the name of a sound file that is used for critical alerts.")
   @JsonProperty(JSON_PROPERTY_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -611,7 +611,7 @@ public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteR
    * Specifies the volume of the critical alert sound. The volume ranges from 0.0to 1.0, which indicates silent and full volume, respectively. (Default &#x3D; 1.0)
    * @return volume
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the volume of the critical alert sound. The volume ranges from 0.0to 1.0, which indicates silent and full volume, respectively. (Default = 1.0)")
   @JsonProperty(JSON_PROPERTY_VOLUME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3PollsGetRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsGetRequest.java
@@ -43,7 +43,7 @@ import org.sendbird.client.JSON;
   V3PollsGetRequest.JSON_PROPERTY_DATA
 })
 @JsonTypeName("_v3_polls_get_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3PollsGetRequest {
   public static final String JSON_PROPERTY_TITLE = "title";
   private String title;
@@ -78,7 +78,7 @@ public class V3PollsGetRequest {
    * Specifies the title of a poll. The length is limited to 2,048 characters.
    * @return title
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the title of a poll. The length is limited to 2,048 characters.")
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -112,7 +112,7 @@ public class V3PollsGetRequest {
    * Specifies an array of poll options that a user can vote for. At least one option should be provided, and the length of each option is limited to 2,000 characters.
    * @return options
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies an array of poll options that a user can vote for. At least one option should be provided, and the length of each option is limited to 2,000 characters.")
   @JsonProperty(JSON_PROPERTY_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -138,7 +138,7 @@ public class V3PollsGetRequest {
    * Determines whether to allow users other than the creator of the poll to add new options to the poll. (Default is false)
    * @return allowUserSuggestion
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to allow users other than the creator of the poll to add new options to the poll. (Default is false)")
   @JsonProperty(JSON_PROPERTY_ALLOW_USER_SUGGESTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -164,7 +164,7 @@ public class V3PollsGetRequest {
    * Determines whether to allow users to vote for multiple options. (Default is false)
    * @return allowMultipleVotes
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to allow users to vote for multiple options. (Default is false)")
   @JsonProperty(JSON_PROPERTY_ALLOW_MULTIPLE_VOTES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -190,7 +190,7 @@ public class V3PollsGetRequest {
    * Specifies when the poll closes and no longer accepts votes in Unix seconds. If the value of this property is -1, the poll is open indefinitely.
    * @return closeAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies when the poll closes and no longer accepts votes in Unix seconds. If the value of this property is -1, the poll is open indefinitely.")
   @JsonProperty(JSON_PROPERTY_CLOSE_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -216,7 +216,7 @@ public class V3PollsGetRequest {
    * Specifies the unique ID of the user who creates the poll.
    * @return createdBy
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of the user who creates the poll.")
   @JsonProperty(JSON_PROPERTY_CREATED_BY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -242,7 +242,7 @@ public class V3PollsGetRequest {
    * Specifies a JSON object of one or more key-value items to store additional poll information.
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies a JSON object of one or more key-value items to store additional poll information.")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdDeleteRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdDeleteRequest.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdDeleteRequest.JSON_PROPERTY_SHOW_PARTIAL_VOTER_LIST
 })
 @JsonTypeName("_v3_polls__poll_id__delete_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3PollsPollIdDeleteRequest {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -60,7 +60,7 @@ public class V3PollsPollIdDeleteRequest {
    * Specifies the URL of the channel. If channel_type is specified, channel_url must be specified as well.
    * @return channelUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the URL of the channel. If channel_type is specified, channel_url must be specified as well.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -86,7 +86,7 @@ public class V3PollsPollIdDeleteRequest {
    * Specifies the type of the channel. Either open_channels or group_channels.
    * @return channelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the type of the channel. Either open_channels or group_channels.")
   @JsonProperty(JSON_PROPERTY_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -112,7 +112,7 @@ public class V3PollsPollIdDeleteRequest {
    * Determines whether to show a partial list of voters for each option. If set to true, the option resources inside the response include the partial_voter_list property which shows up to ten voters.
    * @return showPartialVoterList
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to show a partial list of voters for each option. If set to true, the option resources inside the response include the partial_voter_list property which shows up to ten voters.")
   @JsonProperty(JSON_PROPERTY_SHOW_PARTIAL_VOTER_LIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdDeleteRequest1.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdDeleteRequest1.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdDeleteRequest1.JSON_PROPERTY_DATA
 })
 @JsonTypeName("_v3_polls__poll_id__delete_request_1")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3PollsPollIdDeleteRequest1 {
   public static final String JSON_PROPERTY_TITLE = "title";
   private String title;
@@ -72,7 +72,7 @@ public class V3PollsPollIdDeleteRequest1 {
    * Specifies the title of a poll. The length is limited to 2,000 characters.
    * @return title
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the title of a poll. The length is limited to 2,000 characters.")
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -98,7 +98,7 @@ public class V3PollsPollIdDeleteRequest1 {
    * Determines whether to allow users other than the creator of the poll to add new options to the poll. (Default is false)
    * @return allowUserSuggestion
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to allow users other than the creator of the poll to add new options to the poll. (Default is false)")
   @JsonProperty(JSON_PROPERTY_ALLOW_USER_SUGGESTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -124,7 +124,7 @@ public class V3PollsPollIdDeleteRequest1 {
    * Determines whether to allow users to vote for multiple options. (Default is false)
    * @return allowMultipleVotes
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Determines whether to allow users to vote for multiple options. (Default is false)")
   @JsonProperty(JSON_PROPERTY_ALLOW_MULTIPLE_VOTES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -150,7 +150,7 @@ public class V3PollsPollIdDeleteRequest1 {
    * Specifies when the poll closes and no longer accepts votes in Unix seconds. If the value of this property is -1, the poll is open indefinitely.
    * @return closeAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies when the poll closes and no longer accepts votes in Unix seconds. If the value of this property is -1, the poll is open indefinitely.")
   @JsonProperty(JSON_PROPERTY_CLOSE_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -176,7 +176,7 @@ public class V3PollsPollIdDeleteRequest1 {
    * Specifies the unique ID of the user who creates the poll.
    * @return allocreatedBywMultipleVotes
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of the user who creates the poll.")
   @JsonProperty(JSON_PROPERTY_ALLOCREATED_BYW_MULTIPLE_VOTES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -202,7 +202,7 @@ public class V3PollsPollIdDeleteRequest1 {
    * Specifies a JSON object of one or more key-value items to store additional poll information.
    * @return data
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies a JSON object of one or more key-value items to store additional poll information.")
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdDeleteRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdDeleteRequest.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdOptionsOptionIdDeleteRequest.JSON_PROPERTY_CREATED_BY
 })
 @JsonTypeName("_v3_polls__poll_id__options__option_id__delete_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3PollsPollIdOptionsOptionIdDeleteRequest {
   public static final String JSON_PROPERTY_TEXT = "text";
   private String text;
@@ -56,7 +56,7 @@ public class V3PollsPollIdOptionsOptionIdDeleteRequest {
    * Specifies the description of a new option. The maximum length is 2,000 characters.
    * @return text
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the description of a new option. The maximum length is 2,000 characters.")
   @JsonProperty(JSON_PROPERTY_TEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -82,7 +82,7 @@ public class V3PollsPollIdOptionsOptionIdDeleteRequest {
    * Specifies the unique ID of the user who creates the option.
    * @return createdBy
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of the user who creates the option.")
   @JsonProperty(JSON_PROPERTY_CREATED_BY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGet200Response.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGet200Response.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdOptionsOptionIdVotersGet200Response.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("_v3_polls__poll_id__options__option_id__voters_get_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3PollsPollIdOptionsOptionIdVotersGet200Response {
   public static final String JSON_PROPERTY_VOTE_COUNT = "vote_count";
   private Integer voteCount;
@@ -63,7 +63,7 @@ public class V3PollsPollIdOptionsOptionIdVotersGet200Response {
    * Get voteCount
    * @return voteCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VOTE_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -97,7 +97,7 @@ public class V3PollsPollIdOptionsOptionIdVotersGet200Response {
    * Get voters
    * @return voters
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_VOTERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -123,7 +123,7 @@ public class V3PollsPollIdOptionsOptionIdVotersGet200Response {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("_v3_polls__poll_id__options__option_id__voters_get_200_response_voters_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner {
   public static final String JSON_PROPERTY_NICKNAME = "nickname";
   private String nickname;
@@ -64,7 +64,7 @@ public class V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner {
    * Get nickname
    * @return nickname
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -90,7 +90,7 @@ public class V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner {
    * Get metadata
    * @return metadata
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_METADATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -116,7 +116,7 @@ public class V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner {
    * Get profileUrl
    * @return profileUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -142,7 +142,7 @@ public class V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGetRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGetRequest.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdOptionsOptionIdVotersGetRequest.JSON_PROPERTY_LIMIT
 })
 @JsonTypeName("_v3_polls__poll_id__options__option_id__voters_get_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3PollsPollIdOptionsOptionIdVotersGetRequest {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;
@@ -56,7 +56,7 @@ public class V3PollsPollIdOptionsOptionIdVotersGetRequest {
    * Specifies the token to get the next page of voters. You can get this value from the next property of the previous API response.
    * @return token
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the token to get the next page of voters. You can get this value from the next property of the previous API response.")
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -82,7 +82,7 @@ public class V3PollsPollIdOptionsOptionIdVotersGetRequest {
    * Specifies the number of voters to return per page. Acceptable values are 1 to 100, inclusive. (Default is 100)
    * @return limit
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the number of voters to return per page. Acceptable values are 1 to 100, inclusive. (Default is 100)")
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdVotePutRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdVotePutRequest.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdVotePutRequest.JSON_PROPERTY_OPTION_IDS
 })
 @JsonTypeName("_v3_polls__poll_id__vote_put_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3PollsPollIdVotePutRequest {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -58,7 +58,7 @@ public class V3PollsPollIdVotePutRequest {
    * Specifies the unique ID of a user who casts or cancels a vote.
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the unique ID of a user who casts or cancels a vote.")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -92,7 +92,7 @@ public class V3PollsPollIdVotePutRequest {
    * Specifies the array of option IDs to cast or cancel votes. For example, if a user had voted for both Option 1 and Option 2 in a poll, you can specify this property&#39;s value as [1,2]. If the user wants to cancel the vote for Option 2 but keep the vote for Option 1, the value should be specified as [1]. If the user wants to cancel the votes for both poll options, the value should be specified as [].
    * @return optionIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "Specifies the array of option IDs to cast or cancel votes. For example, if a user had voted for both Option 1 and Option 2 in a poll, you can specify this property's value as [1,2]. If the user wants to cancel the vote for Option 2 but keep the vote for Option 1, the value should be specified as [1]. If the user wants to cancel the votes for both poll options, the value should be specified as [].")
   @JsonProperty(JSON_PROPERTY_OPTION_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3ScheduledMessagesCountGet200Response.java
+++ b/src/main/java/org/openapitools/client/model/V3ScheduledMessagesCountGet200Response.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   V3ScheduledMessagesCountGet200Response.JSON_PROPERTY_COUNT
 })
 @JsonTypeName("_v3_scheduled_messages_count_get_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3ScheduledMessagesCountGet200Response {
   public static final String JSON_PROPERTY_COUNT = "count";
   private BigDecimal count;
@@ -53,7 +53,7 @@ public class V3ScheduledMessagesCountGet200Response {
    * Get count
    * @return count
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/V3ScheduledMessagesGet200Response.java
+++ b/src/main/java/org/openapitools/client/model/V3ScheduledMessagesGet200Response.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   V3ScheduledMessagesGet200Response.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("_v3_scheduled_messages_get_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class V3ScheduledMessagesGet200Response {
   public static final String JSON_PROPERTY_SCHEDULED_MESSAGES = "scheduled_messages";
   private List<SendBirdScheduledMessage> scheduledMessages = null;
@@ -67,7 +67,7 @@ public class V3ScheduledMessagesGet200Response {
    * Get scheduledMessages
    * @return scheduledMessages
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SCHEDULED_MESSAGES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -93,7 +93,7 @@ public class V3ScheduledMessagesGet200Response {
    * Get next
    * @return next
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewAnnouncementByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewAnnouncementByIdResponse.java
@@ -59,7 +59,7 @@ import org.sendbird.client.JSON;
   ViewAnnouncementByIdResponse.JSON_PROPERTY_TARGET_CUSTOM_TYPE
 })
 @JsonTypeName("viewAnnouncementByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewAnnouncementByIdResponse {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;
@@ -139,7 +139,7 @@ public class ViewAnnouncementByIdResponse {
    * Get uniqueId
    * @return uniqueId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNIQUE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -165,7 +165,7 @@ public class ViewAnnouncementByIdResponse {
    * Get announcementGroup
    * @return announcementGroup
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ANNOUNCEMENT_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -191,7 +191,7 @@ public class ViewAnnouncementByIdResponse {
    * Get message
    * @return message
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -217,7 +217,7 @@ public class ViewAnnouncementByIdResponse {
    * Get enablePush
    * @return enablePush
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_PUSH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -243,7 +243,7 @@ public class ViewAnnouncementByIdResponse {
    * Get targetAt
    * @return targetAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -269,7 +269,7 @@ public class ViewAnnouncementByIdResponse {
    * Get targetUserCount
    * @return targetUserCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_USER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -295,7 +295,7 @@ public class ViewAnnouncementByIdResponse {
    * Get targetChannelCount
    * @return targetChannelCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_CHANNEL_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -321,7 +321,7 @@ public class ViewAnnouncementByIdResponse {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -347,7 +347,7 @@ public class ViewAnnouncementByIdResponse {
    * Get scheduledAt
    * @return scheduledAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SCHEDULED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -373,7 +373,7 @@ public class ViewAnnouncementByIdResponse {
    * Get ceaseAt
    * @return ceaseAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CEASE_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -399,7 +399,7 @@ public class ViewAnnouncementByIdResponse {
    * Get resumeAt
    * @return resumeAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_RESUME_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -425,7 +425,7 @@ public class ViewAnnouncementByIdResponse {
    * Get completedAt
    * @return completedAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COMPLETED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -451,7 +451,7 @@ public class ViewAnnouncementByIdResponse {
    * Get sentUserCount
    * @return sentUserCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENT_USER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -477,7 +477,7 @@ public class ViewAnnouncementByIdResponse {
    * Get openCount
    * @return openCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -503,7 +503,7 @@ public class ViewAnnouncementByIdResponse {
    * Get openRate
    * @return openRate
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_OPEN_RATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -529,7 +529,7 @@ public class ViewAnnouncementByIdResponse {
    * Get createChannel
    * @return createChannel
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -555,7 +555,7 @@ public class ViewAnnouncementByIdResponse {
    * Get createChannelOptions
    * @return createChannelOptions
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATE_CHANNEL_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -581,7 +581,7 @@ public class ViewAnnouncementByIdResponse {
    * Get endAt
    * @return endAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -607,7 +607,7 @@ public class ViewAnnouncementByIdResponse {
    * Get markAsRead
    * @return markAsRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MARK_AS_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -633,7 +633,7 @@ public class ViewAnnouncementByIdResponse {
    * Get sentChannelCount
    * @return sentChannelCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENT_CHANNEL_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -659,7 +659,7 @@ public class ViewAnnouncementByIdResponse {
    * Get targetChannelType
    * @return targetChannelType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_CHANNEL_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -685,7 +685,7 @@ public class ViewAnnouncementByIdResponse {
    * Get targetCustomType
    * @return targetCustomType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TARGET_CUSTOM_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewBotByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewBotByIdResponse.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   ViewBotByIdResponse.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("viewBotByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewBotByIdResponse {
   public static final String JSON_PROPERTY_BOT = "bot";
   private CreateBotResponseBot bot;
@@ -74,7 +74,7 @@ public class ViewBotByIdResponse {
    * Get bot
    * @return bot
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -100,7 +100,7 @@ public class ViewBotByIdResponse {
    * Get botCallbackUrl
    * @return botCallbackUrl
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BOT_CALLBACK_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -126,7 +126,7 @@ public class ViewBotByIdResponse {
    * Get enableMarkAsRead
    * @return enableMarkAsRead
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_MARK_AS_READ)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -152,7 +152,7 @@ public class ViewBotByIdResponse {
    * Get isPrivacyMode
    * @return isPrivacyMode
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_IS_PRIVACY_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -178,7 +178,7 @@ public class ViewBotByIdResponse {
    * Get showMember
    * @return showMember
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SHOW_MEMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -204,7 +204,7 @@ public class ViewBotByIdResponse {
    * Get channelInvitationPreference
    * @return channelInvitationPreference
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewChannelInvitationPreferenceResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewChannelInvitationPreferenceResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ViewChannelInvitationPreferenceResponse.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("viewChannelInvitationPreferenceResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewChannelInvitationPreferenceResponse {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;
@@ -52,7 +52,7 @@ public class ViewChannelInvitationPreferenceResponse {
    * Get autoAccept
    * @return autoAccept
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_AUTO_ACCEPT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewCountPreferenceOfChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewCountPreferenceOfChannelByUrlResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ViewCountPreferenceOfChannelByUrlResponse.JSON_PROPERTY_COUNT_PREFERENCE
 })
 @JsonTypeName("viewCountPreferenceOfChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewCountPreferenceOfChannelByUrlResponse {
   public static final String JSON_PROPERTY_COUNT_PREFERENCE = "count_preference";
   private String countPreference;
@@ -52,7 +52,7 @@ public class ViewCountPreferenceOfChannelByUrlResponse {
    * Get countPreference
    * @return countPreference
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_COUNT_PREFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewDataExportByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewDataExportByIdResponse.java
@@ -52,7 +52,7 @@ import org.sendbird.client.JSON;
   ViewDataExportByIdResponse.JSON_PROPERTY_USER_IDS
 })
 @JsonTypeName("viewDataExportByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewDataExportByIdResponse {
   public static final String JSON_PROPERTY_REQUEST_ID = "request_id";
   private String requestId;
@@ -108,7 +108,7 @@ public class ViewDataExportByIdResponse {
    * Get requestId
    * @return requestId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUEST_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -134,7 +134,7 @@ public class ViewDataExportByIdResponse {
    * Get dataType
    * @return dataType
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATA_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -160,7 +160,7 @@ public class ViewDataExportByIdResponse {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -186,7 +186,7 @@ public class ViewDataExportByIdResponse {
    * Get format
    * @return format
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FORMAT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -212,7 +212,7 @@ public class ViewDataExportByIdResponse {
    * Get csvDelimiter
    * @return csvDelimiter
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CSV_DELIMITER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -238,7 +238,7 @@ public class ViewDataExportByIdResponse {
    * Get timezone
    * @return timezone
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TIMEZONE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -264,7 +264,7 @@ public class ViewDataExportByIdResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -290,7 +290,7 @@ public class ViewDataExportByIdResponse {
    * Get startTs
    * @return startTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -316,7 +316,7 @@ public class ViewDataExportByIdResponse {
    * Get endTs
    * @return endTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -350,7 +350,7 @@ public class ViewDataExportByIdResponse {
    * Get channelUrls
    * @return channelUrls
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -384,7 +384,7 @@ public class ViewDataExportByIdResponse {
    * Get channelCustomTypes
    * @return channelCustomTypes
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_CUSTOM_TYPES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -418,7 +418,7 @@ public class ViewDataExportByIdResponse {
    * Get senderIds
    * @return senderIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SENDER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -444,7 +444,7 @@ public class ViewDataExportByIdResponse {
    * Get _file
    * @return _file
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -478,7 +478,7 @@ public class ViewDataExportByIdResponse {
    * Get userIds
    * @return userIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewDefaultChannelInvitationPreferenceResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewDefaultChannelInvitationPreferenceResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ViewDefaultChannelInvitationPreferenceResponse.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("viewDefaultChannelInvitationPreferenceResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewDefaultChannelInvitationPreferenceResponse {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;
@@ -52,7 +52,7 @@ public class ViewDefaultChannelInvitationPreferenceResponse {
    * Get autoAccept
    * @return autoAccept
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_AUTO_ACCEPT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewGdprRequestByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewGdprRequestByIdResponse.java
@@ -46,7 +46,7 @@ import org.sendbird.client.JSON;
   ViewGdprRequestByIdResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("viewGdprRequestByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewGdprRequestByIdResponse {
   public static final String JSON_PROPERTY_REQUEST_ID = "request_id";
   private String requestId;
@@ -84,7 +84,7 @@ public class ViewGdprRequestByIdResponse {
    * Get requestId
    * @return requestId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_REQUEST_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -110,7 +110,7 @@ public class ViewGdprRequestByIdResponse {
    * Get action
    * @return action
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ACTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -136,7 +136,7 @@ public class ViewGdprRequestByIdResponse {
    * Get status
    * @return status
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -162,7 +162,7 @@ public class ViewGdprRequestByIdResponse {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -188,7 +188,7 @@ public class ViewGdprRequestByIdResponse {
    * Get files
    * @return files
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_FILES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -222,7 +222,7 @@ public class ViewGdprRequestByIdResponse {
    * Get userIds
    * @return userIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -248,7 +248,7 @@ public class ViewGdprRequestByIdResponse {
    * Get channelDeleteOption
    * @return channelDeleteOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CHANNEL_DELETE_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -274,7 +274,7 @@ public class ViewGdprRequestByIdResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfChannelsByJoinStatusResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfChannelsByJoinStatusResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfChannelsByJoinStatusResponse.JSON_PROPERTY_GROUP_CHANNEL_COUNT
 })
 @JsonTypeName("viewNumberOfChannelsByJoinStatusResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewNumberOfChannelsByJoinStatusResponse {
   public static final String JSON_PROPERTY_GROUP_CHANNEL_COUNT = "group_channel_count";
   private BigDecimal groupChannelCount;
@@ -53,7 +53,7 @@ public class ViewNumberOfChannelsByJoinStatusResponse {
    * Get groupChannelCount
    * @return groupChannelCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_GROUP_CHANNEL_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfChannelsWithUnreadMessagesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfChannelsWithUnreadMessagesResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfChannelsWithUnreadMessagesResponse.JSON_PROPERTY_UNREAD_COUNT
 })
 @JsonTypeName("viewNumberOfChannelsWithUnreadMessagesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewNumberOfChannelsWithUnreadMessagesResponse {
   public static final String JSON_PROPERTY_UNREAD_COUNT = "unread_count";
   private BigDecimal unreadCount;
@@ -53,7 +53,7 @@ public class ViewNumberOfChannelsWithUnreadMessagesResponse {
    * Get unreadCount
    * @return unreadCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNREAD_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfConcurrentConnectionsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfConcurrentConnectionsResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfConcurrentConnectionsResponse.JSON_PROPERTY_CCU
 })
 @JsonTypeName("viewNumberOfConcurrentConnectionsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewNumberOfConcurrentConnectionsResponse {
   public static final String JSON_PROPERTY_CCU = "ccu";
   private BigDecimal ccu;
@@ -53,7 +53,7 @@ public class ViewNumberOfConcurrentConnectionsResponse {
    * Get ccu
    * @return ccu
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CCU)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfDailyActiveUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfDailyActiveUsersResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfDailyActiveUsersResponse.JSON_PROPERTY_DAU
 })
 @JsonTypeName("viewNumberOfDailyActiveUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewNumberOfDailyActiveUsersResponse {
   public static final String JSON_PROPERTY_DAU = "dau";
   private BigDecimal dau;
@@ -53,7 +53,7 @@ public class ViewNumberOfDailyActiveUsersResponse {
    * Get dau
    * @return dau
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DAU)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfMonthlyActiveUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfMonthlyActiveUsersResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfMonthlyActiveUsersResponse.JSON_PROPERTY_MAU
 })
 @JsonTypeName("viewNumberOfMonthlyActiveUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewNumberOfMonthlyActiveUsersResponse {
   public static final String JSON_PROPERTY_MAU = "mau";
   private BigDecimal mau;
@@ -53,7 +53,7 @@ public class ViewNumberOfMonthlyActiveUsersResponse {
    * Get mau
    * @return mau
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAU)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfPeakConnectionsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfPeakConnectionsResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfPeakConnectionsResponse.JSON_PROPERTY_PEAK_CONNECTIONS
 })
 @JsonTypeName("viewNumberOfPeakConnectionsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewNumberOfPeakConnectionsResponse {
   public static final String JSON_PROPERTY_PEAK_CONNECTIONS = "peak_connections";
   private List<ViewNumberOfPeakConnectionsResponsePeakConnectionsInner> peakConnections = null;
@@ -63,7 +63,7 @@ public class ViewNumberOfPeakConnectionsResponse {
    * Get peakConnections
    * @return peakConnections
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PEAK_CONNECTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfPeakConnectionsResponsePeakConnectionsInner.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfPeakConnectionsResponsePeakConnectionsInner.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfPeakConnectionsResponsePeakConnectionsInner.JSON_PROPERTY_PEAK_CONNECTIONS
 })
 @JsonTypeName("viewNumberOfPeakConnectionsResponse_peak_connections_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewNumberOfPeakConnectionsResponsePeakConnectionsInner {
   public static final String JSON_PROPERTY_DATE = "date";
   private String date;
@@ -57,7 +57,7 @@ public class ViewNumberOfPeakConnectionsResponsePeakConnectionsInner {
    * Get date
    * @return date
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class ViewNumberOfPeakConnectionsResponsePeakConnectionsInner {
    * Get peakConnections
    * @return peakConnections
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PEAK_CONNECTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfUnreadItemsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfUnreadItemsResponse.java
@@ -44,7 +44,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfUnreadItemsResponse.JSON_PROPERTY_NON_SUPER_GROUP_CHANNEL_INVITATION_COUNT
 })
 @JsonTypeName("viewNumberOfUnreadItemsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewNumberOfUnreadItemsResponse {
   public static final String JSON_PROPERTY_NON_SUPER_GROUP_CHANNEL_UNREAD_MESSAGE_COUNT = "non_super_group_channel_unread_message_count";
   private BigDecimal nonSuperGroupChannelUnreadMessageCount;
@@ -85,7 +85,7 @@ public class ViewNumberOfUnreadItemsResponse {
    * Get nonSuperGroupChannelUnreadMessageCount
    * @return nonSuperGroupChannelUnreadMessageCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NON_SUPER_GROUP_CHANNEL_UNREAD_MESSAGE_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -111,7 +111,7 @@ public class ViewNumberOfUnreadItemsResponse {
    * Get superGroupChannelUnreadMessageCount
    * @return superGroupChannelUnreadMessageCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SUPER_GROUP_CHANNEL_UNREAD_MESSAGE_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -137,7 +137,7 @@ public class ViewNumberOfUnreadItemsResponse {
    * Get groupChannelUnreadMessageCount
    * @return groupChannelUnreadMessageCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_GROUP_CHANNEL_UNREAD_MESSAGE_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -163,7 +163,7 @@ public class ViewNumberOfUnreadItemsResponse {
    * Get superGroupChannelInvitationCount
    * @return superGroupChannelInvitationCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SUPER_GROUP_CHANNEL_INVITATION_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -189,7 +189,7 @@ public class ViewNumberOfUnreadItemsResponse {
    * Get groupChannelInvitationCount
    * @return groupChannelInvitationCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_GROUP_CHANNEL_INVITATION_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -215,7 +215,7 @@ public class ViewNumberOfUnreadItemsResponse {
    * Get superGroupChannelUnreadMentionCount
    * @return superGroupChannelUnreadMentionCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SUPER_GROUP_CHANNEL_UNREAD_MENTION_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -241,7 +241,7 @@ public class ViewNumberOfUnreadItemsResponse {
    * Get groupChannelUnreadMentionCount
    * @return groupChannelUnreadMentionCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_GROUP_CHANNEL_UNREAD_MENTION_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -267,7 +267,7 @@ public class ViewNumberOfUnreadItemsResponse {
    * Get nonSuperGroupChannelUnreadMentionCount
    * @return nonSuperGroupChannelUnreadMentionCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NON_SUPER_GROUP_CHANNEL_UNREAD_MENTION_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -293,7 +293,7 @@ public class ViewNumberOfUnreadItemsResponse {
    * Get nonSuperGroupChannelInvitationCount
    * @return nonSuperGroupChannelInvitationCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_NON_SUPER_GROUP_CHANNEL_INVITATION_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfUnreadMessagesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfUnreadMessagesResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfUnreadMessagesResponse.JSON_PROPERTY_UNREAD_COUNT
 })
 @JsonTypeName("viewNumberOfUnreadMessagesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewNumberOfUnreadMessagesResponse {
   public static final String JSON_PROPERTY_UNREAD_COUNT = "unread_count";
   private BigDecimal unreadCount;
@@ -53,7 +53,7 @@ public class ViewNumberOfUnreadMessagesResponse {
    * Get unreadCount
    * @return unreadCount
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_UNREAD_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewPushConfigurationByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewPushConfigurationByIdResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ViewPushConfigurationByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("viewPushConfigurationByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewPushConfigurationByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<ListPushConfigurationsResponsePushConfigurationsInner> pushConfigurations = null;
@@ -63,7 +63,7 @@ public class ViewPushConfigurationByIdResponse {
    * Get pushConfigurations
    * @return pushConfigurations
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_CONFIGURATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewPushNotificationContentTemplateResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewPushNotificationContentTemplateResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ViewPushNotificationContentTemplateResponse.JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES
 })
 @JsonTypeName("viewPushNotificationContentTemplateResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewPushNotificationContentTemplateResponse {
   public static final String JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES = "push_message_templates";
   private List<ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner> pushMessageTemplates = null;
@@ -63,7 +63,7 @@ public class ViewPushNotificationContentTemplateResponse {
    * Get pushMessageTemplates
    * @return pushMessageTemplates
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner.java
+++ b/src/main/java/org/openapitools/client/model/ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner.JSON_PROPERTY_PUSH_MESSAGE_PREVIEW
 })
 @JsonTypeName("viewPushNotificationContentTemplateResponse_push_message_templates_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner {
   public static final String JSON_PROPERTY_TEMPLATE_NAME = "template_name";
   private String templateName;
@@ -61,7 +61,7 @@ public class ViewPushNotificationContentTemplateResponsePushMessageTemplatesInne
    * Get templateName
    * @return templateName
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TEMPLATE_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -87,7 +87,7 @@ public class ViewPushNotificationContentTemplateResponsePushMessageTemplatesInne
    * Get template
    * @return template
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TEMPLATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -113,7 +113,7 @@ public class ViewPushNotificationContentTemplateResponsePushMessageTemplatesInne
    * Get pushMessagePreview
    * @return pushMessagePreview
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_MESSAGE_PREVIEW)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewPushPreferencesForChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewPushPreferencesForChannelByUrlResponse.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   ViewPushPreferencesForChannelByUrlResponse.JSON_PROPERTY_ENABLE
 })
 @JsonTypeName("viewPushPreferencesForChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewPushPreferencesForChannelByUrlResponse {
   public static final String JSON_PROPERTY_PUSH_TRIGGER_OPTION = "push_trigger_option";
   private String pushTriggerOption;
@@ -97,7 +97,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get pushTriggerOption
    * @return pushTriggerOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_TRIGGER_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -123,7 +123,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get doNotDisturb
    * @return doNotDisturb
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DO_NOT_DISTURB)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -149,7 +149,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get startHour
    * @return startHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -175,7 +175,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get startMin
    * @return startMin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -201,7 +201,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get endHour
    * @return endHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -227,7 +227,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get endMin
    * @return endMin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -253,7 +253,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get snoozeEnabled
    * @return snoozeEnabled
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -279,7 +279,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get snoozeStartTs
    * @return snoozeStartTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_START_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -305,7 +305,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get snoozeEndTs
    * @return snoozeEndTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_END_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -331,7 +331,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get timezone
    * @return timezone
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TIMEZONE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -357,7 +357,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get pushSound
    * @return pushSound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -383,7 +383,7 @@ public class ViewPushPreferencesForChannelByUrlResponse {
    * Get enable
    * @return enable
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewPushPreferencesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewPushPreferencesResponse.java
@@ -51,7 +51,7 @@ import org.sendbird.client.JSON;
   ViewPushPreferencesResponse.JSON_PROPERTY_PUSH_TRIGGER_OPTION
 })
 @JsonTypeName("viewPushPreferencesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewPushPreferencesResponse {
   public static final String JSON_PROPERTY_SNOOZE_START_TS = "snooze_start_ts";
   private String snoozeStartTs;
@@ -107,7 +107,7 @@ public class ViewPushPreferencesResponse {
    * Get snoozeStartTs
    * @return snoozeStartTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_START_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -133,7 +133,7 @@ public class ViewPushPreferencesResponse {
    * Get startHour
    * @return startHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -159,7 +159,7 @@ public class ViewPushPreferencesResponse {
    * Get snoozeEnabled
    * @return snoozeEnabled
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -185,7 +185,7 @@ public class ViewPushPreferencesResponse {
    * Get endMin
    * @return endMin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -211,7 +211,7 @@ public class ViewPushPreferencesResponse {
    * Get timezone
    * @return timezone
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TIMEZONE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -237,7 +237,7 @@ public class ViewPushPreferencesResponse {
    * Get blockPushFromBots
    * @return blockPushFromBots
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_BLOCK_PUSH_FROM_BOTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -271,7 +271,7 @@ public class ViewPushPreferencesResponse {
    * Get pushBlockedBotIds
    * @return pushBlockedBotIds
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_BLOCKED_BOT_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -297,7 +297,7 @@ public class ViewPushPreferencesResponse {
    * Get startMin
    * @return startMin
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_START_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -323,7 +323,7 @@ public class ViewPushPreferencesResponse {
    * Get snoozeEndTs
    * @return snoozeEndTs
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_SNOOZE_END_TS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -349,7 +349,7 @@ public class ViewPushPreferencesResponse {
    * Get doNotDisturb
    * @return doNotDisturb
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_DO_NOT_DISTURB)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -375,7 +375,7 @@ public class ViewPushPreferencesResponse {
    * Get endHour
    * @return endHour
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_END_HOUR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -401,7 +401,7 @@ public class ViewPushPreferencesResponse {
    * Get enablePushForReplies
    * @return enablePushForReplies
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ENABLE_PUSH_FOR_REPLIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -427,7 +427,7 @@ public class ViewPushPreferencesResponse {
    * Get pushSound
    * @return pushSound
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_SOUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -453,7 +453,7 @@ public class ViewPushPreferencesResponse {
    * Get pushTriggerOption
    * @return pushTriggerOption
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PUSH_TRIGGER_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewSecondaryApiTokenByTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewSecondaryApiTokenByTokenResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ViewSecondaryApiTokenByTokenResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("viewSecondaryApiTokenByTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewSecondaryApiTokenByTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;
@@ -57,7 +57,7 @@ public class ViewSecondaryApiTokenByTokenResponse {
    * Get token
    * @return token
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -83,7 +83,7 @@ public class ViewSecondaryApiTokenByTokenResponse {
    * Get createdAt
    * @return createdAt
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewTotalNumberOfMessagesInChannelResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewTotalNumberOfMessagesInChannelResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewTotalNumberOfMessagesInChannelResponse.JSON_PROPERTY_TOTAL
 })
 @JsonTypeName("viewTotalNumberOfMessagesInChannelResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewTotalNumberOfMessagesInChannelResponse {
   public static final String JSON_PROPERTY_TOTAL = "total";
   private BigDecimal total;
@@ -53,7 +53,7 @@ public class ViewTotalNumberOfMessagesInChannelResponse {
    * Get total
    * @return total
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewUserMetadataResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewUserMetadataResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ViewUserMetadataResponse.JSON_PROPERTY_ANY_OF
 })
 @JsonTypeName("viewUserMetadataResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewUserMetadataResponse {
   public static final String JSON_PROPERTY_ANY_OF = "anyOf";
   private String anyOf;
@@ -52,7 +52,7 @@ public class ViewUserMetadataResponse {
    * Get anyOf
    * @return anyOf
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_ANY_OF)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/openapitools/client/model/ViewWhoOwnsRegistrationOrDeviceTokenByTokenResponseInner.java
+++ b/src/main/java/org/openapitools/client/model/ViewWhoOwnsRegistrationOrDeviceTokenByTokenResponseInner.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ViewWhoOwnsRegistrationOrDeviceTokenByTokenResponseInner.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("viewWhoOwnsRegistrationOrDeviceTokenByTokenResponse_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ViewWhoOwnsRegistrationOrDeviceTokenByTokenResponseInner {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -52,7 +52,7 @@ public class ViewWhoOwnsRegistrationOrDeviceTokenByTokenResponseInner {
    * Get userId
    * @return userId
   **/
-  @javax.annotation.Nullable
+  @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)

--- a/src/main/java/org/sendbird/client/ApiClient.java
+++ b/src/main/java/org/sendbird/client/ApiClient.java
@@ -1,15 +1,15 @@
 package org.sendbird.client;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
@@ -66,7 +66,7 @@ import org.sendbird.client.auth.ApiKeyAuth;
 /**
  * <p>ApiClient class.</p>
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ApiClient extends JavaTimeFormatter {
   protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
@@ -127,7 +127,7 @@ public class ApiClient extends JavaTimeFormatter {
     this.dateFormat = new RFC3339DateFormat();
 
     // Set default User-Agent.
-    setUserAgent("OpenAPI-Generator/1.0.20/java");
+    setUserAgent("OpenAPI-Generator/1.1.0/java");
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
@@ -151,7 +151,7 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * <p>Getter for the field <code>httpClient</code>.</p>
    *
-   * @return a {@link javax.ws.rs.client.Client} object.
+   * @return a {@link jakarta.ws.rs.client.Client} object.
    */
   public Client getHttpClient() {
     return httpClient;
@@ -160,7 +160,7 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * <p>Setter for the field <code>httpClient</code>.</p>
    *
-   * @param httpClient a {@link javax.ws.rs.client.Client} object.
+   * @param httpClient a {@link jakarta.ws.rs.client.Client} object.
    * @return a {@link org.openapitools.client.ApiClient} object.
    */
   public ApiClient setHttpClient(Client httpClient) {
@@ -885,7 +885,7 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * <p>Prepare the file for download from the response.</p>
    *
-   * @param response a {@link javax.ws.rs.core.Response} object.
+   * @param response a {@link jakarta.ws.rs.core.Response} object.
    * @return a {@link java.io.File} object.
    * @throws java.io.IOException if any.
    */
@@ -1151,7 +1151,7 @@ public class ApiClient extends JavaTimeFormatter {
    * To completely disable certificate validation (at your own risk), you can
    * override this method and invoke disableCertificateValidation(clientBuilder).
    *
-   * @param clientBuilder a {@link javax.ws.rs.client.ClientBuilder} object.
+   * @param clientBuilder a {@link jakarta.ws.rs.client.ClientBuilder} object.
    */
   protected void customizeClientBuilder(ClientBuilder clientBuilder) {
     // No-op extension point
@@ -1163,7 +1163,7 @@ public class ApiClient extends JavaTimeFormatter {
    * Please note that trusting all certificates is extremely risky.
    * This may be useful in a development environment with self-signed certificates.
    *
-   * @param clientBuilder a {@link javax.ws.rs.client.ClientBuilder} object.
+   * @param clientBuilder a {@link jakarta.ws.rs.client.ClientBuilder} object.
    * @throws java.security.KeyManagementException if any.
    * @throws java.security.NoSuchAlgorithmException if any.
    */
@@ -1190,7 +1190,7 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * <p>Build the response headers.</p>
    *
-   * @param response a {@link javax.ws.rs.core.Response} object.
+   * @param response a {@link jakarta.ws.rs.core.Response} object.
    * @return a {@link java.util.Map} of response headers.
    */
   protected Map<String, List<String>> buildResponseHeaders(Response response) {

--- a/src/main/java/org/sendbird/client/ApiException.java
+++ b/src/main/java/org/sendbird/client/ApiException.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * API Exception
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/src/main/java/org/sendbird/client/Configuration.java
+++ b/src/main/java/org/sendbird/client/Configuration.java
@@ -13,7 +13,7 @@
 
 package org.sendbird.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class Configuration {
     private static ApiClient defaultApiClient = new ApiClient();
 

--- a/src/main/java/org/sendbird/client/JSON.java
+++ b/src/main/java/org/sendbird/client/JSON.java
@@ -12,10 +12,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.ext.ContextResolver;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class JSON implements ContextResolver<ObjectMapper> {
   private ObjectMapper mapper;
 

--- a/src/main/java/org/sendbird/client/JSON.java-e
+++ b/src/main/java/org/sendbird/client/JSON.java-e
@@ -12,10 +12,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.ext.ContextResolver;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T14:44:31.188701+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T14:44:31.188701+09:00[Asia/Seoul]")
 public class JSON implements ContextResolver<ObjectMapper> {
   private ObjectMapper mapper;
 

--- a/src/main/java/org/sendbird/client/JavaTimeFormatter.java
+++ b/src/main/java/org/sendbird/client/JavaTimeFormatter.java
@@ -20,7 +20,7 @@ import java.time.format.DateTimeParseException;
  * Class that add parsing/formatting support for Java 8+ {@code OffsetDateTime} class.
  * It's generated for java clients when {@code AbstractJavaCodegen#dateLibrary} specified as {@code java8}.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class JavaTimeFormatter {
 
     private DateTimeFormatter offsetDateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;

--- a/src/main/java/org/sendbird/client/Pair.java
+++ b/src/main/java/org/sendbird/client/Pair.java
@@ -13,7 +13,7 @@
 
 package org.sendbird.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/org/sendbird/client/StringUtil.java
+++ b/src/main/java/org/sendbird/client/StringUtil.java
@@ -16,7 +16,7 @@ package org.sendbird.client;
 import java.util.Collection;
 import java.util.Iterator;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/org/sendbird/client/api/AnnouncementApi.java
+++ b/src/main/java/org/sendbird/client/api/AnnouncementApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.GetDetailedOpenRateOfAnnouncementGroupResponse;
 import org.openapitools.client.model.GetStatisticsDailyResponse;
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class AnnouncementApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/ApplicationApi.java
+++ b/src/main/java/org/sendbird/client/api/ApplicationApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.AddApnsPushConfigurationData;
 import org.openapitools.client.model.AddApnsPushConfigurationResponse;
@@ -54,7 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ApplicationApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/BotApi.java
+++ b/src/main/java/org/sendbird/client/api/BotApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.CreateBotData;
 import org.openapitools.client.model.CreateBotResponse;
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class BotApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/DataExportApi.java
+++ b/src/main/java/org/sendbird/client/api/DataExportApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.ListDataExportsByMessageChannelOrUserResponse;
 import org.openapitools.client.model.RegisterAndScheduleDataExportData;
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class DataExportApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/DeleteAPinApi.java
+++ b/src/main/java/org/sendbird/client/api/DeleteAPinApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.SendBirdChannelResponse;
 
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class DeleteAPinApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/GroupChannelApi.java
+++ b/src/main/java/org/sendbird/client/api/GroupChannelApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.GcAcceptInvitationData;
 import org.openapitools.client.model.GcCheckIfMemberByIdResponse;
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class GroupChannelApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/MessageApi.java
+++ b/src/main/java/org/sendbird/client/api/MessageApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.AddEmojiCategoriesResponse;
 import org.openapitools.client.model.AddEmojisData;
@@ -46,7 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class MessageApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/MetadataApi.java
+++ b/src/main/java/org/sendbird/client/api/MetadataApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.CreateChannelMetacounterData;
 import org.openapitools.client.model.CreateChannelMetadataData;
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class MetadataApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/ModerationApi.java
+++ b/src/main/java/org/sendbird/client/api/ModerationApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.BanFromChannelsWithCustomChannelTypesData;
 import org.openapitools.client.model.BlockUserData;
@@ -44,7 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ModerationApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/OpenChannelApi.java
+++ b/src/main/java/org/sendbird/client/api/OpenChannelApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.OcCreateChannelData;
 import org.openapitools.client.model.OcDeleteChannelByUrl200Response;
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class OpenChannelApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/PinAMessageApi.java
+++ b/src/main/java/org/sendbird/client/api/PinAMessageApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.SendBirdChannelResponse;
 
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class PinAMessageApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/PollApi.java
+++ b/src/main/java/org/sendbird/client/api/PollApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.SendBirdPoll;
 import org.openapitools.client.model.SendBirdPollOption;
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class PollApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/PrivacyApi.java
+++ b/src/main/java/org/sendbird/client/api/PrivacyApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.ListGdprRequestsResponse;
 import org.openapitools.client.model.RegisterGdprRequestData;
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class PrivacyApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/PushNotificationsApi.java
+++ b/src/main/java/org/sendbird/client/api/PushNotificationsApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.ListPushConfigurationsResponse;
 import org.openapitools.client.model.V3ApplicationsPushSettingsGet200Response;
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class PushNotificationsApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/ReportApi.java
+++ b/src/main/java/org/sendbird/client/api/ReportApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.ListReportsOnChannelByUrlResponse;
 import org.openapitools.client.model.ListReportsOnMessageByIdResponse;
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ReportApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/ScheduledMessageApi.java
+++ b/src/main/java/org/sendbird/client/api/ScheduledMessageApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteRequest;
 import org.openapitools.client.model.V3ScheduledMessagesCountGet200Response;
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ScheduledMessageApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/StatisticsApi.java
+++ b/src/main/java/org/sendbird/client/api/StatisticsApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.GetDetailedOpenRateOfAnnouncementByIdResponse;
 import org.openapitools.client.model.GetDetailedOpenStatusOfAnnouncementByIdResponse;
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class StatisticsApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/UserApi.java
+++ b/src/main/java/org/sendbird/client/api/UserApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.AddRegistrationOrDeviceTokenData;
 import org.openapitools.client.model.AddRegistrationOrDeviceTokenResponse;
@@ -49,7 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class UserApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/WebhookApi.java
+++ b/src/main/java/org/sendbird/client/api/WebhookApi.java
@@ -6,7 +6,7 @@ import org.sendbird.client.ApiResponse;
 import org.sendbird.client.Configuration;
 import org.sendbird.client.Pair;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.openapitools.client.model.ChooseWhichEventsToSubscribeToData;
 import org.openapitools.client.model.ChooseWhichEventsToSubscribeToResponse;
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class WebhookApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/auth/ApiKeyAuth.java
+++ b/src/main/java/org/sendbird/client/auth/ApiKeyAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/org/sendbird/client/auth/HttpBasicAuth.java
+++ b/src/main/java/org/sendbird/client/auth/HttpBasicAuth.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class HttpBasicAuth implements Authentication {
   private String username;
   private String password;

--- a/src/main/java/org/sendbird/client/auth/HttpBearerAuth.java
+++ b/src/main/java/org/sendbird/client/auth/HttpBearerAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
+@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2023-11-24T21:22:01.103596+09:00[Asia/Seoul]")
 public class HttpBearerAuth implements Authentication {
   private final String scheme;
   private String bearerToken;


### PR DESCRIPTION
Dear Sendbird team,

My team is actively using your library and has recently migrated to Spring Boot 3, which requires Java 17 and Jakarta EE 10 as minimal versions. We took time to migrate your library to be compliant with these requirements, and it works great for us. The only thing I didn't touch was android build configuration, as we don't use it and I have no means to test if it works correctly. 

We thought this could be useful to share this with you, as we want to use the official version of your sdk 🙂 

Please let me know what you think and what I can do to help you. 