### PR TITLE
Updated version to 1.0.25

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -125,7 +125,6 @@ docs/ListGdprRequestsResponseRequestsInner.md
 docs/ListMessagesResponse.md
 docs/ListMessagesResponseMessagesInner.md
 docs/ListMessagesResponseMessagesInnerOgTag.md
-docs/ListMessagesResponseMessagesInnerOgTagOgImage.md
 docs/ListMessagesResponseMessagesInnerSortedMetaarrayInner.md
 docs/ListMutedChannelsResponse.md
 docs/ListMutedUsersInChannelsWithCustomChannelType200Response.md
@@ -461,7 +460,6 @@ src/main/java/org/openapitools/client/model/ListGdprRequestsResponseRequestsInne
 src/main/java/org/openapitools/client/model/ListMessagesResponse.java
 src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInner.java
 src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerOgTag.java
-src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerOgTagOgImage.java
 src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerSortedMetaarrayInner.java
 src/main/java/org/openapitools/client/model/ListMutedChannelsResponse.java
 src/main/java/org/openapitools/client/model/ListMutedUsersInChannelsWithCustomChannelType200Response.java

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6799,7 +6799,9 @@ paths:
         name: user_ids
         required: false
         schema:
-          type: string
+          items:
+            type: string
+          type: array
         style: form
       responses:
         "200":
@@ -11281,8 +11283,6 @@ components:
           type: string
         is_ephemeral:
           type: boolean
-        is_frozen:
-          type: boolean
         name:
           type: string
         url:
@@ -11722,7 +11722,6 @@ components:
           is_online: true
           last_seen_at: 0
           is_hide_me_from_friends: true
-        is_frozen: true
         is_ephemeral: true
         my_count_preference: my_count_preference
         my_member_state: invited
@@ -11793,8 +11792,6 @@ components:
         is_distinct:
           type: boolean
         is_ephemeral:
-          type: boolean
-        is_frozen:
           type: boolean
         is_hidden:
           type: boolean
@@ -11973,6 +11970,13 @@ components:
           type: array
       type: object
     SendBird.OGImage:
+      example:
+        alt: alt
+        secure_url: secure_url
+        width: 7.061401241503109
+        type: type
+        url: url
+        height: 2.3021358869347655
       properties:
         alt:
           type: string
@@ -12032,7 +12036,6 @@ components:
           last_seen_at: 0
           is_hide_me_from_friends: true
         data: data
-        is_frozen: true
         custom_type: custom_type
         is_ephemeral: true
         created_at: 0.8008281904610115
@@ -12119,8 +12122,6 @@ components:
         is_dynamic_partitioned:
           type: boolean
         is_ephemeral:
-          type: boolean
-        is_frozen:
           type: boolean
         max_length_message:
           type: number
@@ -13696,7 +13697,6 @@ components:
             is_online: true
             last_seen_at: 0
             is_hide_me_from_friends: true
-          is_frozen: true
           is_ephemeral: true
           my_count_preference: my_count_preference
           my_member_state: invited
@@ -14007,7 +14007,6 @@ components:
             is_online: true
             last_seen_at: 0
             is_hide_me_from_friends: true
-          is_frozen: true
           is_ephemeral: true
           my_count_preference: my_count_preference
           my_member_state: invited
@@ -14358,14 +14357,10 @@ components:
           is_online: true
           last_seen_at: 0
           is_hide_me_from_friends: true
-        token:
-        - token
-        - token
+        token: token
       properties:
         token:
-          items:
-            type: string
-          type: array
+          type: string
         user:
           $ref: '#/components/schemas/SendBird.User'
       type: object
@@ -14698,7 +14693,6 @@ components:
             last_seen_at: 0
             is_hide_me_from_friends: true
           data: data
-          is_frozen: true
           custom_type: custom_type
           is_ephemeral: true
           created_at: 0.8008281904610115
@@ -14799,7 +14793,6 @@ components:
             last_seen_at: 0
             is_hide_me_from_friends: true
           data: data
-          is_frozen: true
           custom_type: custom_type
           is_ephemeral: true
           created_at: 0.8008281904610115
@@ -15720,7 +15713,6 @@ components:
             is_online: true
             last_seen_at: 0
             is_hide_me_from_friends: true
-          is_frozen: true
           is_ephemeral: true
           my_count_preference: my_count_preference
           my_member_state: invited
@@ -16031,7 +16023,6 @@ components:
             is_online: true
             last_seen_at: 0
             is_hide_me_from_friends: true
-          is_frozen: true
           is_ephemeral: true
           my_count_preference: my_count_preference
           my_member_state: invited
@@ -17158,10 +17149,12 @@ components:
           is_op_msg: true
           og_tag:
             og:image:
+              alt: alt
               secure_url: secure_url
-              width: 2.3021358869347655
+              width: 7.061401241503109
+              type: type
               url: url
-              height: 7.061401241503109
+              height: 2.3021358869347655
             og:title: og:title
             og:url: og:url
             og:description: og:description
@@ -17305,10 +17298,12 @@ components:
           is_op_msg: true
           og_tag:
             og:image:
+              alt: alt
               secure_url: secure_url
-              width: 2.3021358869347655
+              width: 7.061401241503109
+              type: type
               url: url
-              height: 7.061401241503109
+              height: 2.3021358869347655
             og:title: og:title
             og:url: og:url
             og:description: og:description
@@ -18257,7 +18252,6 @@ components:
             is_online: true
             last_seen_at: 0
             is_hide_me_from_friends: true
-          is_frozen: true
           is_ephemeral: true
           my_count_preference: my_count_preference
           my_member_state: invited
@@ -18568,7 +18562,6 @@ components:
             is_online: true
             last_seen_at: 0
             is_hide_me_from_friends: true
-          is_frozen: true
           is_ephemeral: true
           my_count_preference: my_count_preference
           my_member_state: invited
@@ -21709,8 +21702,6 @@ components:
             with the is_active property above.
           type: boolean
       required:
-      - nickname
-      - profile_url
       - user_id
       title: updateUserByIdData
       type: object
@@ -22073,13 +22064,6 @@ components:
           type: array
       required:
       - channel_url
-      - cover_file
-      - cover_url
-      - custom_type
-      - data
-      - name
-      - operator_ids
-      - operators
       title: ocUpdateChannelByUrlData
       type: object
     ocDeleteChannelByUrl_200_response:
@@ -24795,29 +24779,15 @@ components:
             type: string
           type: array
       type: object
-    listMessagesResponse_messages_inner_og_tag_og_image:
-      example:
-        secure_url: secure_url
-        width: 2.3021358869347655
-        url: url
-        height: 7.061401241503109
-      properties:
-        url:
-          type: string
-        secure_url:
-          type: string
-        width:
-          type: number
-        height:
-          type: number
-      type: object
     listMessagesResponse_messages_inner_og_tag:
       example:
         og:image:
+          alt: alt
           secure_url: secure_url
-          width: 2.3021358869347655
+          width: 7.061401241503109
+          type: type
           url: url
-          height: 7.061401241503109
+          height: 2.3021358869347655
         og:title: og:title
         og:url: og:url
         og:description: og:description
@@ -24829,7 +24799,7 @@ components:
         og:description:
           type: string
         og:image:
-          $ref: '#/components/schemas/listMessagesResponse_messages_inner_og_tag_og_image'
+          $ref: '#/components/schemas/SendBird.OGImage'
       type: object
     listMessagesResponse_messages_inner:
       example:
@@ -24947,10 +24917,12 @@ components:
         is_op_msg: true
         og_tag:
           og:image:
+            alt: alt
             secure_url: secure_url
-            width: 2.3021358869347655
+            width: 7.061401241503109
+            type: type
             url: url
-            height: 7.061401241503109
+            height: 2.3021358869347655
           og:title: og:title
           og:url: og:url
           og:description: og:description

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'com.diffplug.spotless'
 
 group = 'org.sendbird'
-version = '1.0.23'
+version = '1.0.25'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "org.sendbird",
     name := "sendbird-platform-sdk",
-    version := "1.0.23",
+    version := "1.0.25",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     Compile / javacOptions ++= Seq("-Xlint:deprecation"),

--- a/docs/ListMessagesResponseMessagesInnerOgTag.md
+++ b/docs/ListMessagesResponseMessagesInnerOgTag.md
@@ -10,7 +10,7 @@
 |**ogColonUrl** | **String** |  |  [optional] |
 |**ogColonTitle** | **String** |  |  [optional] |
 |**ogColonDescription** | **String** |  |  [optional] |
-|**ogColonImage** | [**ListMessagesResponseMessagesInnerOgTagOgImage**](ListMessagesResponseMessagesInnerOgTagOgImage.md) |  |  [optional] |
+|**ogColonImage** | [**SendBirdOGImage**](SendBirdOGImage.md) |  |  [optional] |
 
 
 

--- a/docs/MessageApi.md
+++ b/docs/MessageApi.md
@@ -835,7 +835,7 @@ public class Example {
         MessageApi apiInstance = new MessageApi(defaultClient);
         String channelUrl = "channelUrl_example"; // String | 
         String apiToken = "{{API_TOKEN}}"; // String | 
-        String userIds = "userIds_example"; // String | 
+        List<String> userIds = Arrays.asList(); // List<String> | 
         try {
             GcViewNumberOfEachMembersUnreadMessagesResponse result = api.gcViewNumberOfEachMembersUnreadMessages(channelUrl)
                 .apiToken(apiToken)
@@ -860,7 +860,7 @@ public class Example {
 |------------- | ------------- | ------------- | -------------|
 | **channelUrl** | **String**|  | |
 | **apiToken** | **String**|  | [optional] |
-| **userIds** | **String**|  | [optional] |
+| **userIds** | **List&lt;String&gt;**|  | [optional] |
 
 ### Return type
 

--- a/docs/OcUpdateChannelByUrlData.md
+++ b/docs/OcUpdateChannelByUrlData.md
@@ -8,13 +8,13 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**channelUrl** | **String** | Specifies the URL of the channel to update. |  |
-|**name** | **String** | Specifies the channel topic, or the name of the channel. The length is limited to 191 characters. |  |
-|**coverUrl** | **String** | Specifies the URL of the cover image. The length is limited to 2,048 characters. |  |
-|**coverFile** | **File** | Uploads the file for the channel cover image. |  |
-|**customType** | **String** | Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.&lt;br /&gt;&lt;br /&gt; Custom types are also used within Sendbird&#39;s [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views. |  |
-|**data** | **String** | Specifies additional channel information such as a long description of the channel or &#x60;JSON&#x60; formatted string. |  |
-|**operatorIds** | **List&lt;String&gt;** | Specifies an array of one or more user IDs to register as operators of the channel. The maximum allowed number of operators per channel is 100. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.&lt;br/&gt;&lt;br/&gt;  Operators cannot view messages that have been [moderated by](/docs/chat/v3/platform-api/guides/filter-and-moderation) the domain filter or profanity filter. Only the sender will be notified that the message has been blocked. |  |
-|**operators** | **List&lt;String&gt;** | (Deprecated) Specifies the string IDs of the users registered as channel operators. Operators can delete any messages in the channel, and can also receive all messages that have been throttled. |  |
+|**name** | **String** | Specifies the channel topic, or the name of the channel. The length is limited to 191 characters. |  [optional] |
+|**coverUrl** | **String** | Specifies the URL of the cover image. The length is limited to 2,048 characters. |  [optional] |
+|**coverFile** | **File** | Uploads the file for the channel cover image. |  [optional] |
+|**customType** | **String** | Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.&lt;br /&gt;&lt;br /&gt; Custom types are also used within Sendbird&#39;s [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views. |  [optional] |
+|**data** | **String** | Specifies additional channel information such as a long description of the channel or &#x60;JSON&#x60; formatted string. |  [optional] |
+|**operatorIds** | **List&lt;String&gt;** | Specifies an array of one or more user IDs to register as operators of the channel. The maximum allowed number of operators per channel is 100. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.&lt;br/&gt;&lt;br/&gt;  Operators cannot view messages that have been [moderated by](/docs/chat/v3/platform-api/guides/filter-and-moderation) the domain filter or profanity filter. Only the sender will be notified that the message has been blocked. |  [optional] |
+|**operators** | **List&lt;String&gt;** | (Deprecated) Specifies the string IDs of the users registered as channel operators. Operators can delete any messages in the channel, and can also receive all messages that have been throttled. |  [optional] |
 
 
 

--- a/docs/RemoveRegistrationOrDeviceTokenByTokenResponse.md
+++ b/docs/RemoveRegistrationOrDeviceTokenByTokenResponse.md
@@ -7,7 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**token** | **List&lt;String&gt;** |  |  [optional] |
+|**token** | **String** |  |  [optional] |
 |**user** | [**SendBirdUser**](SendBirdUser.md) |  |  [optional] |
 
 

--- a/docs/SendBirdBaseChannel.md
+++ b/docs/SendBirdBaseChannel.md
@@ -13,7 +13,6 @@
 |**customType** | **String** |  |  [optional] |
 |**data** | **String** |  |  [optional] |
 |**isEphemeral** | **Boolean** |  |  [optional] |
-|**isFrozen** | **Boolean** |  |  [optional] |
 |**name** | **String** |  |  [optional] |
 |**url** | **String** |  |  [optional] |
 

--- a/docs/SendBirdGroupChannel.md
+++ b/docs/SendBirdGroupChannel.md
@@ -26,7 +26,6 @@
 |**isDiscoverable** | **Boolean** |  |  [optional] |
 |**isDistinct** | **Boolean** |  |  [optional] |
 |**isEphemeral** | **Boolean** |  |  [optional] |
-|**isFrozen** | **Boolean** |  |  [optional] |
 |**isHidden** | **Boolean** |  |  [optional] |
 |**isPublic** | **Boolean** |  |  [optional] |
 |**isPushEnabled** | **Boolean** |  |  [optional] |

--- a/docs/SendBirdOpenChannel.md
+++ b/docs/SendBirdOpenChannel.md
@@ -16,7 +16,6 @@
 |**data** | **String** |  |  [optional] |
 |**isDynamicPartitioned** | **Boolean** |  |  [optional] |
 |**isEphemeral** | **Boolean** |  |  [optional] |
-|**isFrozen** | **Boolean** |  |  [optional] |
 |**maxLengthMessage** | **BigDecimal** |  |  [optional] |
 |**operators** | [**List&lt;SendBirdUser&gt;**](SendBirdUser.md) |  |  [optional] |
 |**participantCount** | **BigDecimal** |  |  [optional] |

--- a/docs/UpdateUserByIdData.md
+++ b/docs/UpdateUserByIdData.md
@@ -8,8 +8,8 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**userId** | **String** | Specifies the unique ID of the user to update. |  |
-|**nickname** | **String** | Specifies the user&#39;s nickname. The length is limited to 80 characters. |  |
-|**profileUrl** | **String** | Specifies the URL of the user&#39;s profile image. The length is limited to 2,048 characters.&lt;br /&gt;&lt;br /&gt; The [domain filter](/docs/chat/v3/platform-api/guides/filter-and-moderation#2-domain-filter) filters out the request if the value of this property matches the filter&#39;s domain set. |  |
+|**nickname** | **String** | Specifies the user&#39;s nickname. The length is limited to 80 characters. |  [optional] |
+|**profileUrl** | **String** | Specifies the URL of the user&#39;s profile image. The length is limited to 2,048 characters.&lt;br /&gt;&lt;br /&gt; The [domain filter](/docs/chat/v3/platform-api/guides/filter-and-moderation#2-domain-filter) filters out the request if the value of this property matches the filter&#39;s domain set. |  [optional] |
 |**profileFile** | **File** | Uploads the file of the user&#39;s profile image. An acceptable image is limited to &#x60;JPG&#x60; (.jpg), &#x60;JPEG&#x60; (.jpeg), or &#x60;PNG&#x60; (.png) file of up to 25 MB. |  [optional] |
 |**issueAccessToken** | **Boolean** | Determines whether to revoke the existing access token and create a new one for the user. If true, an opaque string token is issued and provided upon creation, which should be passed whenever the user logs in. If false, an access token is not required when the user logs in. (Default: false) |  [optional] |
 |**issueSessionToken** | **Boolean** | Determines whether to add a new session token for the user. If true, an opaque string token is issued and provided upon creation, which should be passed whenever the user logs in. If false, a session token is not required when the user logs in. (Default: false) |  [optional] |

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>sendbird-platform-sdk</artifactId>
     <packaging>jar</packaging>
     <name>sendbird-platform-sdk</name>
-    <version>1.0.23</version>
+    <version>1.0.25</version>
     <url>https://github.com/sendbird/sendbird-platform-sdk-java</url>
     <description>Sendbird Platform API SDK</description>
     <scm>

--- a/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationData.java
+++ b/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationData.java
@@ -43,7 +43,7 @@ import org.sendbird.client.JSON;
   AddApnsPushConfigurationData.JSON_PROPERTY_APNS_TYPE
 })
 @JsonTypeName("addApnsPushConfigurationData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddApnsPushConfigurationData {
   public static final String JSON_PROPERTY_APNS_CERT = "apns_cert";
   private File apnsCert;

--- a/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddApnsPushConfigurationResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("addApnsPushConfigurationResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddApnsPushConfigurationResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<AddApnsPushConfigurationResponsePushConfigurationsInner> pushConfigurations = null;

--- a/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationResponsePushConfigurationsInner.java
+++ b/src/main/java/org/openapitools/client/model/AddApnsPushConfigurationResponsePushConfigurationsInner.java
@@ -45,7 +45,7 @@ import org.sendbird.client.JSON;
   AddApnsPushConfigurationResponsePushConfigurationsInner.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("addApnsPushConfigurationResponse_push_configurations_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddApnsPushConfigurationResponsePushConfigurationsInner {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;

--- a/src/main/java/org/openapitools/client/model/AddEmojiCategoriesResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddEmojiCategoriesResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddEmojiCategoriesResponse.JSON_PROPERTY_EMOJI_CATEGORIES
 })
 @JsonTypeName("addEmojiCategoriesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddEmojiCategoriesResponse {
   public static final String JSON_PROPERTY_EMOJI_CATEGORIES = "emoji_categories";
   private List<AddEmojiCategoriesResponseEmojiCategoriesInner> emojiCategories = null;

--- a/src/main/java/org/openapitools/client/model/AddEmojiCategoriesResponseEmojiCategoriesInner.java
+++ b/src/main/java/org/openapitools/client/model/AddEmojiCategoriesResponseEmojiCategoriesInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddEmojiCategoriesResponseEmojiCategoriesInner.JSON_PROPERTY_URL
 })
 @JsonTypeName("addEmojiCategoriesResponse_emoji_categories_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddEmojiCategoriesResponseEmojiCategoriesInner {
   public static final String JSON_PROPERTY_ID = "id";
   private BigDecimal id;

--- a/src/main/java/org/openapitools/client/model/AddEmojisData.java
+++ b/src/main/java/org/openapitools/client/model/AddEmojisData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddEmojisData.JSON_PROPERTY_EMOJIS
 })
 @JsonTypeName("addEmojisData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddEmojisData {
   public static final String JSON_PROPERTY_EMOJI_CATEGORY_ID = "emoji_category_id";
   private Integer emojiCategoryId;

--- a/src/main/java/org/openapitools/client/model/AddEmojisResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddEmojisResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddEmojisResponse.JSON_PROPERTY_EMOJIS
 })
 @JsonTypeName("addEmojisResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddEmojisResponse {
   public static final String JSON_PROPERTY_EMOJIS = "emojis";
   private List<ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisInner> emojis = null;

--- a/src/main/java/org/openapitools/client/model/AddExtraDataToMessageData.java
+++ b/src/main/java/org/openapitools/client/model/AddExtraDataToMessageData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddExtraDataToMessageData.JSON_PROPERTY_SORTED_METAARRAY
 })
 @JsonTypeName("addExtraDataToMessageData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddExtraDataToMessageData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;

--- a/src/main/java/org/openapitools/client/model/AddExtraDataToMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddExtraDataToMessageResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddExtraDataToMessageResponse.JSON_PROPERTY_SORTED_METAARRAY
 })
 @JsonTypeName("addExtraDataToMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddExtraDataToMessageResponse {
   public static final String JSON_PROPERTY_SORTED_METAARRAY = "sorted_metaarray";
   private List<ListMessagesResponseMessagesInnerSortedMetaarrayInner> sortedMetaarray = null;

--- a/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationData.java
+++ b/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   AddFcmPushConfigurationData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("addFcmPushConfigurationData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddFcmPushConfigurationData {
   public static final String JSON_PROPERTY_API_KEY = "api_key";
   private String apiKey;

--- a/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddFcmPushConfigurationResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("addFcmPushConfigurationResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddFcmPushConfigurationResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<AddFcmPushConfigurationResponsePushConfigurationsInner> pushConfigurations = null;

--- a/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationResponsePushConfigurationsInner.java
+++ b/src/main/java/org/openapitools/client/model/AddFcmPushConfigurationResponsePushConfigurationsInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddFcmPushConfigurationResponsePushConfigurationsInner.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("addFcmPushConfigurationResponse_push_configurations_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddFcmPushConfigurationResponsePushConfigurationsInner {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;

--- a/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationData.java
+++ b/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   AddHmsPushConfigurationData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("addHmsPushConfigurationData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddHmsPushConfigurationData {
   public static final String JSON_PROPERTY_HUAWEI_APP_ID = "huawei_app_id";
   private String huaweiAppId;

--- a/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddHmsPushConfigurationResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("addHmsPushConfigurationResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddHmsPushConfigurationResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<AddHmsPushConfigurationResponsePushConfigurationsInner> pushConfigurations = null;

--- a/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationResponsePushConfigurationsInner.java
+++ b/src/main/java/org/openapitools/client/model/AddHmsPushConfigurationResponsePushConfigurationsInner.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   AddHmsPushConfigurationResponsePushConfigurationsInner.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("addHmsPushConfigurationResponse_push_configurations_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddHmsPushConfigurationResponsePushConfigurationsInner {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;

--- a/src/main/java/org/openapitools/client/model/AddIpToWhitelistData.java
+++ b/src/main/java/org/openapitools/client/model/AddIpToWhitelistData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   AddIpToWhitelistData.JSON_PROPERTY_IP_WHITELIST_ADDRESSES
 })
 @JsonTypeName("addIpToWhitelistData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddIpToWhitelistData {
   public static final String JSON_PROPERTY_IP_WHITELIST_ADDRESSES = "ip_whitelist_addresses";
   private List<String> ipWhitelistAddresses = new ArrayList<>();

--- a/src/main/java/org/openapitools/client/model/AddIpToWhitelistResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddIpToWhitelistResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   AddIpToWhitelistResponse.JSON_PROPERTY_IP_WHITELIST_ADDRESSES
 })
 @JsonTypeName("addIpToWhitelistResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddIpToWhitelistResponse {
   public static final String JSON_PROPERTY_IP_WHITELIST_ADDRESSES = "ip_whitelist_addresses";
   private List<String> ipWhitelistAddresses = null;

--- a/src/main/java/org/openapitools/client/model/AddReactionToAMessageData.java
+++ b/src/main/java/org/openapitools/client/model/AddReactionToAMessageData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   AddReactionToAMessageData.JSON_PROPERTY_REACTION
 })
 @JsonTypeName("addReactionToAMessageData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddReactionToAMessageData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;

--- a/src/main/java/org/openapitools/client/model/AddReactionToAMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddReactionToAMessageResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   AddReactionToAMessageResponse.JSON_PROPERTY_MSG_ID
 })
 @JsonTypeName("addReactionToAMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddReactionToAMessageResponse {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/openapitools/client/model/AddRegistrationOrDeviceTokenData.java
+++ b/src/main/java/org/openapitools/client/model/AddRegistrationOrDeviceTokenData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   AddRegistrationOrDeviceTokenData.JSON_PROPERTY_APNS_DEVICE_TOKEN
 })
 @JsonTypeName("addRegistrationOrDeviceTokenData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddRegistrationOrDeviceTokenData {
   public static final String JSON_PROPERTY_GCM_REG_TOKEN = "gcm_reg_token";
   private String gcmRegToken;

--- a/src/main/java/org/openapitools/client/model/AddRegistrationOrDeviceTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/AddRegistrationOrDeviceTokenResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   AddRegistrationOrDeviceTokenResponse.JSON_PROPERTY_USER
 })
 @JsonTypeName("addRegistrationOrDeviceTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AddRegistrationOrDeviceTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;

--- a/src/main/java/org/openapitools/client/model/BanFromChannelsWithCustomChannelTypesData.java
+++ b/src/main/java/org/openapitools/client/model/BanFromChannelsWithCustomChannelTypesData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   BanFromChannelsWithCustomChannelTypesData.JSON_PROPERTY_CHANNEL_CUSTOM_TYPES
 })
 @JsonTypeName("banFromChannelsWithCustomChannelTypesData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class BanFromChannelsWithCustomChannelTypesData {
   public static final String JSON_PROPERTY_CHANNEL_CUSTOM_TYPES = "channel_custom_types";
   private List<String> channelCustomTypes = new ArrayList<>();

--- a/src/main/java/org/openapitools/client/model/BanUsersInChannelsWithCustomChannelTypeData.java
+++ b/src/main/java/org/openapitools/client/model/BanUsersInChannelsWithCustomChannelTypeData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   BanUsersInChannelsWithCustomChannelTypeData.JSON_PROPERTY_ON_DEMAND_UPSERT
 })
 @JsonTypeName("banUsersInChannelsWithCustomChannelTypeData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class BanUsersInChannelsWithCustomChannelTypeData {
   public static final String JSON_PROPERTY_BANNED_LIST = "banned_list";
   private List<BanUsersInChannelsWithCustomChannelTypeDataBannedListInner> bannedList = new ArrayList<>();

--- a/src/main/java/org/openapitools/client/model/BanUsersInChannelsWithCustomChannelTypeDataBannedListInner.java
+++ b/src/main/java/org/openapitools/client/model/BanUsersInChannelsWithCustomChannelTypeDataBannedListInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   BanUsersInChannelsWithCustomChannelTypeDataBannedListInner.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("banUsersInChannelsWithCustomChannelTypeData_banned_list_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class BanUsersInChannelsWithCustomChannelTypeDataBannedListInner {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/openapitools/client/model/Blob.java
+++ b/src/main/java/org/openapitools/client/model/Blob.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   Blob.JSON_PROPERTY_SIZE,
   Blob.JSON_PROPERTY_TYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class Blob {
   public static final String JSON_PROPERTY_SIZE = "size";
   private BigDecimal size;

--- a/src/main/java/org/openapitools/client/model/BlockUserData.java
+++ b/src/main/java/org/openapitools/client/model/BlockUserData.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   BlockUserData.JSON_PROPERTY_USERS
 })
 @JsonTypeName("blockUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class BlockUserData {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/openapitools/client/model/BlockUserResponse.java
+++ b/src/main/java/org/openapitools/client/model/BlockUserResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   BlockUserResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("blockUserResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class BlockUserResponse {
   public static final String JSON_PROPERTY_USERS = "users";
   private List<String> users = null;

--- a/src/main/java/org/openapitools/client/model/ChoosePushNotificationContentTemplateResponse.java
+++ b/src/main/java/org/openapitools/client/model/ChoosePushNotificationContentTemplateResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ChoosePushNotificationContentTemplateResponse.JSON_PROPERTY_NAME
 })
 @JsonTypeName("choosePushNotificationContentTemplateResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ChoosePushNotificationContentTemplateResponse {
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;

--- a/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToData.java
+++ b/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToData.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   ChooseWhichEventsToSubscribeToData.JSON_PROPERTY_ENABLED_EVENTS
 })
 @JsonTypeName("chooseWhichEventsToSubscribeToData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ChooseWhichEventsToSubscribeToData {
   public static final String JSON_PROPERTY_ENABLED = "enabled";
   private Boolean enabled;

--- a/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToResponse.java
+++ b/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ChooseWhichEventsToSubscribeToResponse.JSON_PROPERTY_WEBHOOK
 })
 @JsonTypeName("chooseWhichEventsToSubscribeToResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ChooseWhichEventsToSubscribeToResponse {
   public static final String JSON_PROPERTY_WEBHOOK = "webhook";
   private ChooseWhichEventsToSubscribeToResponseWebhook webhook;

--- a/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToResponseWebhook.java
+++ b/src/main/java/org/openapitools/client/model/ChooseWhichEventsToSubscribeToResponseWebhook.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   ChooseWhichEventsToSubscribeToResponseWebhook.JSON_PROPERTY_INCLUDE_UNREAD_COUNT
 })
 @JsonTypeName("chooseWhichEventsToSubscribeToResponse_webhook")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ChooseWhichEventsToSubscribeToResponseWebhook {
   public static final String JSON_PROPERTY_ENABLED = "enabled";
   private Boolean enabled;

--- a/src/main/java/org/openapitools/client/model/ConfigureAutoEventData.java
+++ b/src/main/java/org/openapitools/client/model/ConfigureAutoEventData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ConfigureAutoEventData.JSON_PROPERTY_AUTO_EVENT_MESSAGE
 })
 @JsonTypeName("configureAutoEventData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ConfigureAutoEventData {
   public static final String JSON_PROPERTY_AUTO_EVENT_MESSAGE = "auto_event_message";
   private ConfigureAutoEventDataAutoEventMessage autoEventMessage;

--- a/src/main/java/org/openapitools/client/model/ConfigureAutoEventDataAutoEventMessage.java
+++ b/src/main/java/org/openapitools/client/model/ConfigureAutoEventDataAutoEventMessage.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ConfigureAutoEventDataAutoEventMessage.JSON_PROPERTY_CHANNEL_CHANGE
 })
 @JsonTypeName("configureAutoEventData_auto_event_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ConfigureAutoEventDataAutoEventMessage {
   public static final String JSON_PROPERTY_USER_LEAVE = "user_leave";
   private Object userLeave;

--- a/src/main/java/org/openapitools/client/model/CreateBotData.java
+++ b/src/main/java/org/openapitools/client/model/CreateBotData.java
@@ -43,7 +43,7 @@ import org.sendbird.client.JSON;
   CreateBotData.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("createBotData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateBotData {
   public static final String JSON_PROPERTY_BOT_USERID = "bot_userid";
   private String botUserid;

--- a/src/main/java/org/openapitools/client/model/CreateBotResponse.java
+++ b/src/main/java/org/openapitools/client/model/CreateBotResponse.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   CreateBotResponse.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("createBotResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateBotResponse {
   public static final String JSON_PROPERTY_BOT = "bot";
   private CreateBotResponseBot bot;

--- a/src/main/java/org/openapitools/client/model/CreateBotResponseBot.java
+++ b/src/main/java/org/openapitools/client/model/CreateBotResponseBot.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   CreateBotResponseBot.JSON_PROPERTY_BOT_METADATA
 })
 @JsonTypeName("createBotResponse_bot")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateBotResponseBot {
   public static final String JSON_PROPERTY_BOT_TOKEN = "bot_token";
   private String botToken;

--- a/src/main/java/org/openapitools/client/model/CreateChannelMetacounterData.java
+++ b/src/main/java/org/openapitools/client/model/CreateChannelMetacounterData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   CreateChannelMetacounterData.JSON_PROPERTY_METACOUNTER
 })
 @JsonTypeName("createChannelMetacounterData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateChannelMetacounterData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;

--- a/src/main/java/org/openapitools/client/model/CreateChannelMetadataData.java
+++ b/src/main/java/org/openapitools/client/model/CreateChannelMetadataData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   CreateChannelMetadataData.JSON_PROPERTY_INCLUDE_TS
 })
 @JsonTypeName("createChannelMetadataData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateChannelMetadataData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;

--- a/src/main/java/org/openapitools/client/model/CreateChannelMetadataResponse.java
+++ b/src/main/java/org/openapitools/client/model/CreateChannelMetadataResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   CreateChannelMetadataResponse.JSON_PROPERTY_INCLUDE_TS
 })
 @JsonTypeName("createChannelMetadataResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateChannelMetadataResponse {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   private Map<String, String> metadata = null;

--- a/src/main/java/org/openapitools/client/model/CreateUserData.java
+++ b/src/main/java/org/openapitools/client/model/CreateUserData.java
@@ -44,7 +44,7 @@ import org.sendbird.client.JSON;
   CreateUserData.JSON_PROPERTY_METADATA
 })
 @JsonTypeName("createUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateUserData {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/openapitools/client/model/CreateUserMetadataData.java
+++ b/src/main/java/org/openapitools/client/model/CreateUserMetadataData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   CreateUserMetadataData.JSON_PROPERTY_METADATA
 })
 @JsonTypeName("createUserMetadataData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateUserMetadataData {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   private Object metadata;

--- a/src/main/java/org/openapitools/client/model/CreateUserMetadataResponse.java
+++ b/src/main/java/org/openapitools/client/model/CreateUserMetadataResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   CreateUserMetadataResponse.JSON_PROPERTY_ANY_OF
 })
 @JsonTypeName("createUserMetadataResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateUserMetadataResponse {
   public static final String JSON_PROPERTY_ANY_OF = "anyOf";
   private String anyOf;

--- a/src/main/java/org/openapitools/client/model/CreateUserTokenData.java
+++ b/src/main/java/org/openapitools/client/model/CreateUserTokenData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   CreateUserTokenData.JSON_PROPERTY_EXPIRES_AT
 })
 @JsonTypeName("createUserTokenData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateUserTokenData {
   public static final String JSON_PROPERTY_EXPIRES_AT = "expires_at";
   private BigDecimal expiresAt;

--- a/src/main/java/org/openapitools/client/model/CreateUserTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/CreateUserTokenResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   CreateUserTokenResponse.JSON_PROPERTY_EXPIRES_AT
 })
 @JsonTypeName("createUserTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CreateUserTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;

--- a/src/main/java/org/openapitools/client/model/CustomTypeListBannedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/CustomTypeListBannedUsersResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   CustomTypeListBannedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("customTypeListBannedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class CustomTypeListBannedUsersResponse {
   public static final String JSON_PROPERTY_BANNED_LIST = "banned_list";
   private List<OcListBannedUsersResponseBannedListInner> bannedList = null;

--- a/src/main/java/org/openapitools/client/model/DeleteAllowedIpsFromWhitelistResponse.java
+++ b/src/main/java/org/openapitools/client/model/DeleteAllowedIpsFromWhitelistResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   DeleteAllowedIpsFromWhitelistResponse.JSON_PROPERTY_IP_WHITELIST_ADDRESSES
 })
 @JsonTypeName("deleteAllowedIpsFromWhitelistResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class DeleteAllowedIpsFromWhitelistResponse {
   public static final String JSON_PROPERTY_IP_WHITELIST_ADDRESSES = "ip_whitelist_addresses";
   private List<String> ipWhitelistAddresses = null;

--- a/src/main/java/org/openapitools/client/model/DeleteApnsCertificateByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/DeleteApnsCertificateByIdResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   DeleteApnsCertificateByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("deleteApnsCertificateByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class DeleteApnsCertificateByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<String> pushConfigurations = null;

--- a/src/main/java/org/openapitools/client/model/EnableReactionsData.java
+++ b/src/main/java/org/openapitools/client/model/EnableReactionsData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   EnableReactionsData.JSON_PROPERTY_ENABLED
 })
 @JsonTypeName("enableReactionsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class EnableReactionsData {
   public static final String JSON_PROPERTY_ENABLED = "enabled";
   private Boolean enabled;

--- a/src/main/java/org/openapitools/client/model/EnableReactionsResponse.java
+++ b/src/main/java/org/openapitools/client/model/EnableReactionsResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   EnableReactionsResponse.JSON_PROPERTY_REACTIONS
 })
 @JsonTypeName("enableReactionsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class EnableReactionsResponse {
   public static final String JSON_PROPERTY_REACTIONS = "reactions";
   private Boolean reactions;

--- a/src/main/java/org/openapitools/client/model/Function.java
+++ b/src/main/java/org/openapitools/client/model/Function.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   Function.JSON_PROPERTY_LENGTH,
   Function.JSON_PROPERTY_PROTOTYPE
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class Function {
   public static final String JSON_PROPERTY_ARGUMENTS = "arguments";
   private JsonNullable<Object> arguments = JsonNullable.<Object>of(null);

--- a/src/main/java/org/openapitools/client/model/GcAcceptInvitationData.java
+++ b/src/main/java/org/openapitools/client/model/GcAcceptInvitationData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcAcceptInvitationData.JSON_PROPERTY_ACCESS_CODE
 })
 @JsonTypeName("gcAcceptInvitationData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcAcceptInvitationData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcBanUserData.java
+++ b/src/main/java/org/openapitools/client/model/GcBanUserData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcBanUserData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcBanUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcBanUserData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcBanUserResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcBanUserResponse.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   GcBanUserResponse.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("gcBanUserResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcBanUserResponse {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;

--- a/src/main/java/org/openapitools/client/model/GcCheckIfMemberByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcCheckIfMemberByIdResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   GcCheckIfMemberByIdResponse.JSON_PROPERTY_STATE
 })
 @JsonTypeName("gcCheckIfMemberByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcCheckIfMemberByIdResponse {
   public static final String JSON_PROPERTY_IS_MEMBER = "is_member";
   private Boolean isMember;

--- a/src/main/java/org/openapitools/client/model/GcCreateChannelData.java
+++ b/src/main/java/org/openapitools/client/model/GcCreateChannelData.java
@@ -57,7 +57,7 @@ import org.sendbird.client.JSON;
   GcCreateChannelData.JSON_PROPERTY_BLOCK_SDK_USER_CHANNEL_JOIN
 })
 @JsonTypeName("gcCreateChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcCreateChannelData {
   public static final String JSON_PROPERTY_USER_IDS = "user_ids";
   private List<String> userIds = new ArrayList<>();

--- a/src/main/java/org/openapitools/client/model/GcDeclineInvitationData.java
+++ b/src/main/java/org/openapitools/client/model/GcDeclineInvitationData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   GcDeclineInvitationData.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("gcDeclineInvitationData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcDeclineInvitationData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcFreezeChannelData.java
+++ b/src/main/java/org/openapitools/client/model/GcFreezeChannelData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   GcFreezeChannelData.JSON_PROPERTY_FREEZE
 })
 @JsonTypeName("gcFreezeChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcFreezeChannelData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcHideOrArchiveChannelData.java
+++ b/src/main/java/org/openapitools/client/model/GcHideOrArchiveChannelData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcHideOrArchiveChannelData.JSON_PROPERTY_HIDE_PREVIOUS_MESSAGES
 })
 @JsonTypeName("gcHideOrArchiveChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcHideOrArchiveChannelData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcInviteAsMembersData.java
+++ b/src/main/java/org/openapitools/client/model/GcInviteAsMembersData.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   GcInviteAsMembersData.JSON_PROPERTY_HIDDEN_STATUS
 })
 @JsonTypeName("gcInviteAsMembersData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcInviteAsMembersData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcJoinChannelData.java
+++ b/src/main/java/org/openapitools/client/model/GcJoinChannelData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcJoinChannelData.JSON_PROPERTY_ACCESS_CODE
 })
 @JsonTypeName("gcJoinChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcJoinChannelData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcLeaveChannelData.java
+++ b/src/main/java/org/openapitools/client/model/GcLeaveChannelData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcLeaveChannelData.JSON_PROPERTY_SHOULD_LEAVE_ALL
 })
 @JsonTypeName("gcLeaveChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcLeaveChannelData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcListBannedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcListBannedUsersResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   GcListBannedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("gcListBannedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcListBannedUsersResponse {
   public static final String JSON_PROPERTY_BANNED_LIST = "banned_list";
   private List<OcListBannedUsersResponseBannedListInner> bannedList = null;

--- a/src/main/java/org/openapitools/client/model/GcListChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcListChannelsResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   GcListChannelsResponse.JSON_PROPERTY_TS
 })
 @JsonTypeName("gcListChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcListChannelsResponse {
   public static final String JSON_PROPERTY_CHANNELS = "channels";
   private List<SendBirdGroupChannel> channels = null;

--- a/src/main/java/org/openapitools/client/model/GcListMembersResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcListMembersResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcListMembersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("gcListMembersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcListMembersResponse {
   public static final String JSON_PROPERTY_MEMBERS = "members";
   private List<SendBirdUser> members = null;

--- a/src/main/java/org/openapitools/client/model/GcListMutedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcListMutedUsersResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   GcListMutedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("gcListMutedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcListMutedUsersResponse {
   public static final String JSON_PROPERTY_MUTED_LIST = "muted_list";
   private List<SendBirdUser> mutedList = null;

--- a/src/main/java/org/openapitools/client/model/GcListOperatorsResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcListOperatorsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcListOperatorsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("gcListOperatorsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcListOperatorsResponse {
   public static final String JSON_PROPERTY_OPERATORS = "operators";
   private List<SendBirdUser> operators = null;

--- a/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsDeliveredData.java
+++ b/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsDeliveredData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcMarkAllMessagesAsDeliveredData.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("gcMarkAllMessagesAsDeliveredData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcMarkAllMessagesAsDeliveredData {
   public static final String JSON_PROPERTY_APPLICATION_ID = "application_id";
   private String applicationId;

--- a/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsDeliveredResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsDeliveredResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   GcMarkAllMessagesAsDeliveredResponse.JSON_PROPERTY_TS
 })
 @JsonTypeName("gcMarkAllMessagesAsDeliveredResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcMarkAllMessagesAsDeliveredResponse {
   public static final String JSON_PROPERTY_TS = "ts";
   private BigDecimal ts;

--- a/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsReadData.java
+++ b/src/main/java/org/openapitools/client/model/GcMarkAllMessagesAsReadData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcMarkAllMessagesAsReadData.JSON_PROPERTY_TIMESTAMP
 })
 @JsonTypeName("gcMarkAllMessagesAsReadData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcMarkAllMessagesAsReadData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcMuteUserData.java
+++ b/src/main/java/org/openapitools/client/model/GcMuteUserData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   GcMuteUserData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcMuteUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcMuteUserData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcRegisterOperatorsData.java
+++ b/src/main/java/org/openapitools/client/model/GcRegisterOperatorsData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   GcRegisterOperatorsData.JSON_PROPERTY_OPERATOR_IDS
 })
 @JsonTypeName("gcRegisterOperatorsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcRegisterOperatorsData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcRegisterOperatorsResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcRegisterOperatorsResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcRegisterOperatorsResponse.JSON_PROPERTY_OPERATOR_IDS
 })
 @JsonTypeName("gcRegisterOperatorsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcRegisterOperatorsResponse {
   public static final String JSON_PROPERTY_OPERATOR_IDS = "operator_ids";
   private List<String> operatorIds = null;

--- a/src/main/java/org/openapitools/client/model/GcResetChatHistoryData.java
+++ b/src/main/java/org/openapitools/client/model/GcResetChatHistoryData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcResetChatHistoryData.JSON_PROPERTY_RESET_ALL
 })
 @JsonTypeName("gcResetChatHistoryData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcResetChatHistoryData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcResetChatHistoryResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcResetChatHistoryResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   GcResetChatHistoryResponse.JSON_PROPERTY_TS_MESSAGE_OFFSET
 })
 @JsonTypeName("gcResetChatHistoryResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcResetChatHistoryResponse {
   public static final String JSON_PROPERTY_TS_MESSAGE_OFFSET = "ts_message_offset";
   private BigDecimal tsMessageOffset;

--- a/src/main/java/org/openapitools/client/model/GcTypingIndicatorsData.java
+++ b/src/main/java/org/openapitools/client/model/GcTypingIndicatorsData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GcTypingIndicatorsData.JSON_PROPERTY_USER_IDS
 })
 @JsonTypeName("gcTypingIndicatorsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcTypingIndicatorsData {
   public static final String JSON_PROPERTY_USER_IDS = "user_ids";
   private List<String> userIds = new ArrayList<>();

--- a/src/main/java/org/openapitools/client/model/GcUpdateBanByIdData.java
+++ b/src/main/java/org/openapitools/client/model/GcUpdateBanByIdData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   GcUpdateBanByIdData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcUpdateBanByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcUpdateBanByIdData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcUpdateBanByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcUpdateBanByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GcUpdateBanByIdResponse.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcUpdateBanByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcUpdateBanByIdResponse {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;

--- a/src/main/java/org/openapitools/client/model/GcUpdateChannelByUrlData.java
+++ b/src/main/java/org/openapitools/client/model/GcUpdateChannelByUrlData.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   GcUpdateChannelByUrlData.JSON_PROPERTY_OPERATOR_IDS
 })
 @JsonTypeName("gcUpdateChannelByUrlData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcUpdateChannelByUrlData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/GcViewBanByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcViewBanByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GcViewBanByIdResponse.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcViewBanByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcViewBanByIdResponse {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;

--- a/src/main/java/org/openapitools/client/model/GcViewMuteByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcViewMuteByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GcViewMuteByIdResponse.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("gcViewMuteByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcViewMuteByIdResponse {
   public static final String JSON_PROPERTY_IS_MUTED = "is_muted";
   private Boolean isMuted;

--- a/src/main/java/org/openapitools/client/model/GcViewNumberOfEachMembersUnreadMessagesResponse.java
+++ b/src/main/java/org/openapitools/client/model/GcViewNumberOfEachMembersUnreadMessagesResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GcViewNumberOfEachMembersUnreadMessagesResponse.JSON_PROPERTY_UNREAD
 })
 @JsonTypeName("gcViewNumberOfEachMembersUnreadMessagesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GcViewNumberOfEachMembersUnreadMessagesResponse {
   public static final String JSON_PROPERTY_UNREAD = "unread";
   private Map<String, BigDecimal> unread = null;

--- a/src/main/java/org/openapitools/client/model/GenerateSecondaryApiTokenData.java
+++ b/src/main/java/org/openapitools/client/model/GenerateSecondaryApiTokenData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   GenerateSecondaryApiTokenData.JSON_PROPERTY_H_T_T_P_A_P_I_T_O_K_E_N
 })
 @JsonTypeName("generateSecondaryApiTokenData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GenerateSecondaryApiTokenData {
   public static final String JSON_PROPERTY_H_T_T_P_A_P_I_T_O_K_E_N = "HTTP_API_TOKEN";
   private String HTTP_API_TOKEN;

--- a/src/main/java/org/openapitools/client/model/GenerateSecondaryApiTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/GenerateSecondaryApiTokenResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   GenerateSecondaryApiTokenResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("generateSecondaryApiTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GenerateSecondaryApiTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;

--- a/src/main/java/org/openapitools/client/model/GetDetailedOpenRateOfAnnouncementByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetDetailedOpenRateOfAnnouncementByIdResponse.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   GetDetailedOpenRateOfAnnouncementByIdResponse.JSON_PROPERTY_CUMULATIVE_OPEN_RATES
 })
 @JsonTypeName("getDetailedOpenRateOfAnnouncementByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GetDetailedOpenRateOfAnnouncementByIdResponse {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;

--- a/src/main/java/org/openapitools/client/model/GetDetailedOpenRateOfAnnouncementGroupResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetDetailedOpenRateOfAnnouncementGroupResponse.java
@@ -43,7 +43,7 @@ import org.sendbird.client.JSON;
   GetDetailedOpenRateOfAnnouncementGroupResponse.JSON_PROPERTY_CUMULATIVE_OPEN_RATES
 })
 @JsonTypeName("getDetailedOpenRateOfAnnouncementGroupResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GetDetailedOpenRateOfAnnouncementGroupResponse {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;

--- a/src/main/java/org/openapitools/client/model/GetDetailedOpenStatusOfAnnouncementByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetDetailedOpenStatusOfAnnouncementByIdResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   GetDetailedOpenStatusOfAnnouncementByIdResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("getDetailedOpenStatusOfAnnouncementByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GetDetailedOpenStatusOfAnnouncementByIdResponse {
   public static final String JSON_PROPERTY_OPEN_STATUS = "open_status";
   private List<GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner> openStatus = null;

--- a/src/main/java/org/openapitools/client/model/GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner.java
+++ b/src/main/java/org/openapitools/client/model/GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner.JSON_PROPERTY_OPEN_AT
 })
 @JsonTypeName("getDetailedOpenStatusOfAnnouncementByIdResponse_open_status_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GetDetailedOpenStatusOfAnnouncementByIdResponseOpenStatusInner {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/openapitools/client/model/GetStatisticsDailyResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetStatisticsDailyResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GetStatisticsDailyResponse.JSON_PROPERTY_WEEK
 })
 @JsonTypeName("getStatisticsDailyResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GetStatisticsDailyResponse {
   public static final String JSON_PROPERTY_STATISTICS = "statistics";
   private List<GetStatisticsDailyResponseStatisticsInner> statistics = null;

--- a/src/main/java/org/openapitools/client/model/GetStatisticsDailyResponseStatisticsInner.java
+++ b/src/main/java/org/openapitools/client/model/GetStatisticsDailyResponseStatisticsInner.java
@@ -46,7 +46,7 @@ import org.sendbird.client.JSON;
   GetStatisticsDailyResponseStatisticsInner.JSON_PROPERTY_OPEN_COUNT
 })
 @JsonTypeName("getStatisticsDailyResponse_statistics_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GetStatisticsDailyResponseStatisticsInner {
   public static final String JSON_PROPERTY_DATE_RANGE = "date_range";
   private String dateRange;

--- a/src/main/java/org/openapitools/client/model/GetStatisticsMonthlyResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetStatisticsMonthlyResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GetStatisticsMonthlyResponse.JSON_PROPERTY_WEEK
 })
 @JsonTypeName("getStatisticsMonthlyResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GetStatisticsMonthlyResponse {
   public static final String JSON_PROPERTY_STATISTICS = "statistics";
   private List<GetStatisticsDailyResponseStatisticsInner> statistics = null;

--- a/src/main/java/org/openapitools/client/model/GetStatisticsResponse.java
+++ b/src/main/java/org/openapitools/client/model/GetStatisticsResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   GetStatisticsResponse.JSON_PROPERTY_WEEK
 })
 @JsonTypeName("getStatisticsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GetStatisticsResponse {
   public static final String JSON_PROPERTY_STATISTICS = "statistics";
   private List<GetStatisticsDailyResponseStatisticsInner> statistics = null;

--- a/src/main/java/org/openapitools/client/model/JoinChannelsData.java
+++ b/src/main/java/org/openapitools/client/model/JoinChannelsData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   JoinChannelsData.JSON_PROPERTY_CHANNEL_URLS
 })
 @JsonTypeName("joinChannelsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class JoinChannelsData {
   public static final String JSON_PROPERTY_BOT_USERID = "bot_userid";
   private String botUserid;

--- a/src/main/java/org/openapitools/client/model/JoinChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/JoinChannelsResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   JoinChannelsResponse.JSON_PROPERTY_CHANNELS
 })
 @JsonTypeName("joinChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class JoinChannelsResponse {
   public static final String JSON_PROPERTY_CHANNELS = "channels";
   private List<SendBirdGroupChannel> channels = null;

--- a/src/main/java/org/openapitools/client/model/LeaveMyGroupChannelsData.java
+++ b/src/main/java/org/openapitools/client/model/LeaveMyGroupChannelsData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   LeaveMyGroupChannelsData.JSON_PROPERTY_CUSTOM_TYPE
 })
 @JsonTypeName("leaveMyGroupChannelsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class LeaveMyGroupChannelsData {
   public static final String JSON_PROPERTY_CUSTOM_TYPE = "custom_type";
   private String customType;

--- a/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListAllEmojisAndEmojiCategoriesResponse.JSON_PROPERTY_EMOJI_CATEGORIES
 })
 @JsonTypeName("listAllEmojisAndEmojiCategoriesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListAllEmojisAndEmojiCategoriesResponse {
   public static final String JSON_PROPERTY_EMOJI_HASH = "emoji_hash";
   private String emojiHash;

--- a/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner.java
+++ b/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner.JSON_PROPERTY_EMOJIS
 })
 @JsonTypeName("listAllEmojisAndEmojiCategoriesResponse_emoji_categories_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInner {
   public static final String JSON_PROPERTY_ID = "id";
   private BigDecimal id;

--- a/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisInner.java
+++ b/src/main/java/org/openapitools/client/model/ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisInner.JSON_PROPERTY_URL
 })
 @JsonTypeName("listAllEmojisAndEmojiCategoriesResponse_emoji_categories_inner_emojis_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListAllEmojisAndEmojiCategoriesResponseEmojiCategoriesInnerEmojisInner {
   public static final String JSON_PROPERTY_ID = "id";
   private BigDecimal id;

--- a/src/main/java/org/openapitools/client/model/ListAnnouncementGroupsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListAnnouncementGroupsResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListAnnouncementGroupsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listAnnouncementGroupsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListAnnouncementGroupsResponse {
   public static final String JSON_PROPERTY_ANNOUNCEMENT_GROUPS = "announcement_groups";
   private List<String> announcementGroups = null;

--- a/src/main/java/org/openapitools/client/model/ListAnnouncementsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListAnnouncementsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListAnnouncementsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listAnnouncementsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListAnnouncementsResponse {
   public static final String JSON_PROPERTY_ANNOUNCEMENTS = "announcements";
   private List<ListAnnouncementsResponseAnnouncementsInner> announcements = null;

--- a/src/main/java/org/openapitools/client/model/ListAnnouncementsResponseAnnouncementsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListAnnouncementsResponseAnnouncementsInner.java
@@ -59,7 +59,7 @@ import org.sendbird.client.JSON;
   ListAnnouncementsResponseAnnouncementsInner.JSON_PROPERTY_TARGET_CUSTOM_TYPE
 })
 @JsonTypeName("listAnnouncementsResponse_announcements_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListAnnouncementsResponseAnnouncementsInner {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;

--- a/src/main/java/org/openapitools/client/model/ListBannedChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListBannedChannelsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListBannedChannelsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listBannedChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListBannedChannelsResponse {
   public static final String JSON_PROPERTY_BANNED_CHANNELS = "banned_channels";
   private List<ListBannedChannelsResponseBannedChannelsInner> bannedChannels = null;

--- a/src/main/java/org/openapitools/client/model/ListBannedChannelsResponseBannedChannelsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListBannedChannelsResponseBannedChannelsInner.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   ListBannedChannelsResponseBannedChannelsInner.JSON_PROPERTY_END_AT
 })
 @JsonTypeName("listBannedChannelsResponse_banned_channels_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListBannedChannelsResponseBannedChannelsInner {
   public static final String JSON_PROPERTY_START_AT = "start_at";
   private BigDecimal startAt;

--- a/src/main/java/org/openapitools/client/model/ListBlockedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListBlockedUsersResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListBlockedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listBlockedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListBlockedUsersResponse {
   public static final String JSON_PROPERTY_USERS = "users";
   private List<SendBirdUser> users = null;

--- a/src/main/java/org/openapitools/client/model/ListBotsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListBotsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListBotsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listBotsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListBotsResponse {
   public static final String JSON_PROPERTY_BOTS = "bots";
   private List<ListBotsResponseBotsInner> bots = null;

--- a/src/main/java/org/openapitools/client/model/ListBotsResponseBotsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListBotsResponseBotsInner.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   ListBotsResponseBotsInner.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("listBotsResponse_bots_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListBotsResponseBotsInner {
   public static final String JSON_PROPERTY_BOT = "bot";
   private CreateBotResponseBot bot;

--- a/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListDataExportsByMessageChannelOrUserResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listDataExportsByMessageChannelOrUserResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListDataExportsByMessageChannelOrUserResponse {
   public static final String JSON_PROPERTY_EXPORTED_DATA = "exported_data";
   private List<ListDataExportsByMessageChannelOrUserResponseExportedDataInner> exportedData = null;

--- a/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponseExportedDataInner.java
+++ b/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponseExportedDataInner.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ListDataExportsByMessageChannelOrUserResponseExportedDataInner.JSON_PROPERTY_USER_IDS
 })
 @JsonTypeName("listDataExportsByMessageChannelOrUserResponse_exported_data_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListDataExportsByMessageChannelOrUserResponseExportedDataInner {
   public static final String JSON_PROPERTY_REQUEST_ID = "request_id";
   private String requestId;

--- a/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponseExportedDataInnerFile.java
+++ b/src/main/java/org/openapitools/client/model/ListDataExportsByMessageChannelOrUserResponseExportedDataInnerFile.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ListDataExportsByMessageChannelOrUserResponseExportedDataInnerFile.JSON_PROPERTY_EXPIRES_AT
 })
 @JsonTypeName("listDataExportsByMessageChannelOrUserResponse_exported_data_inner_file")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListDataExportsByMessageChannelOrUserResponseExportedDataInnerFile {
   public static final String JSON_PROPERTY_URL = "url";
   private String url;

--- a/src/main/java/org/openapitools/client/model/ListEmojisResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListEmojisResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListEmojisResponse.JSON_PROPERTY_EMOJIS
 })
 @JsonTypeName("listEmojisResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListEmojisResponse {
   public static final String JSON_PROPERTY_EMOJIS = "emojis";
   private List<SendBirdEmoji> emojis = null;

--- a/src/main/java/org/openapitools/client/model/ListGdprRequestsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListGdprRequestsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListGdprRequestsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listGdprRequestsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListGdprRequestsResponse {
   public static final String JSON_PROPERTY_REQUESTS = "requests";
   private List<ListGdprRequestsResponseRequestsInner> requests = null;

--- a/src/main/java/org/openapitools/client/model/ListGdprRequestsResponseRequestsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListGdprRequestsResponseRequestsInner.java
@@ -46,7 +46,7 @@ import org.sendbird.client.JSON;
   ListGdprRequestsResponseRequestsInner.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("listGdprRequestsResponse_requests_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListGdprRequestsResponseRequestsInner {
   public static final String JSON_PROPERTY_REQUEST_ID = "request_id";
   private String requestId;

--- a/src/main/java/org/openapitools/client/model/ListMessagesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListMessagesResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListMessagesResponse.JSON_PROPERTY_MESSAGES
 })
 @JsonTypeName("listMessagesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListMessagesResponse {
   public static final String JSON_PROPERTY_MESSAGES = "messages";
   private List<ListMessagesResponseMessagesInner> messages = null;

--- a/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInner.java
+++ b/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInner.java
@@ -65,7 +65,7 @@ import org.sendbird.client.JSON;
   ListMessagesResponseMessagesInner.JSON_PROPERTY_PARENT_MESSAGE_INFO
 })
 @JsonTypeName("listMessagesResponse_messages_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListMessagesResponseMessagesInner {
   public static final String JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS = "message_survival_seconds";
   private BigDecimal messageSurvivalSeconds;

--- a/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerOgTag.java
+++ b/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerOgTag.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import org.openapitools.client.model.ListMessagesResponseMessagesInnerOgTagOgImage;
+import org.openapitools.client.model.SendBirdOGImage;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.sendbird.client.JSON;
 
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListMessagesResponseMessagesInnerOgTag.JSON_PROPERTY_OG_COLON_IMAGE
 })
 @JsonTypeName("listMessagesResponse_messages_inner_og_tag")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListMessagesResponseMessagesInnerOgTag {
   public static final String JSON_PROPERTY_OG_COLON_URL = "og:url";
   private String ogColonUrl;
@@ -51,7 +51,7 @@ public class ListMessagesResponseMessagesInnerOgTag {
   private String ogColonDescription;
 
   public static final String JSON_PROPERTY_OG_COLON_IMAGE = "og:image";
-  private ListMessagesResponseMessagesInnerOgTagOgImage ogColonImage;
+  private SendBirdOGImage ogColonImage;
 
   public ListMessagesResponseMessagesInnerOgTag() { 
   }
@@ -134,7 +134,7 @@ public class ListMessagesResponseMessagesInnerOgTag {
   }
 
 
-  public ListMessagesResponseMessagesInnerOgTag ogColonImage(ListMessagesResponseMessagesInnerOgTagOgImage ogColonImage) {
+  public ListMessagesResponseMessagesInnerOgTag ogColonImage(SendBirdOGImage ogColonImage) {
     this.ogColonImage = ogColonImage;
     return this;
   }
@@ -148,14 +148,14 @@ public class ListMessagesResponseMessagesInnerOgTag {
   @JsonProperty(JSON_PROPERTY_OG_COLON_IMAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public ListMessagesResponseMessagesInnerOgTagOgImage getOgColonImage() {
+  public SendBirdOGImage getOgColonImage() {
     return ogColonImage;
   }
 
 
   @JsonProperty(JSON_PROPERTY_OG_COLON_IMAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setOgColonImage(ListMessagesResponseMessagesInnerOgTagOgImage ogColonImage) {
+  public void setOgColonImage(SendBirdOGImage ogColonImage) {
     this.ogColonImage = ogColonImage;
   }
 

--- a/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerSortedMetaarrayInner.java
+++ b/src/main/java/org/openapitools/client/model/ListMessagesResponseMessagesInnerSortedMetaarrayInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListMessagesResponseMessagesInnerSortedMetaarrayInner.JSON_PROPERTY_VALUE
 })
 @JsonTypeName("listMessagesResponse_messages_inner_sorted_metaarray_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListMessagesResponseMessagesInnerSortedMetaarrayInner {
   public static final String JSON_PROPERTY_KEY = "key";
   private String key;

--- a/src/main/java/org/openapitools/client/model/ListMutedChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListMutedChannelsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListMutedChannelsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listMutedChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListMutedChannelsResponse {
   public static final String JSON_PROPERTY_MUTED_CHANNELS = "muted_channels";
   private List<SendBirdChannelResponse> mutedChannels = null;

--- a/src/main/java/org/openapitools/client/model/ListMutedUsersInChannelsWithCustomChannelType200Response.java
+++ b/src/main/java/org/openapitools/client/model/ListMutedUsersInChannelsWithCustomChannelType200Response.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListMutedUsersInChannelsWithCustomChannelType200Response.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listMutedUsersInChannelsWithCustomChannelType_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListMutedUsersInChannelsWithCustomChannelType200Response {
   public static final String JSON_PROPERTY_MUTED_LIST = "muted_list";
   private List<SendBirdUser> mutedList = null;

--- a/src/main/java/org/openapitools/client/model/ListMyGroupChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListMyGroupChannelsResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   ListMyGroupChannelsResponse.JSON_PROPERTY_TS
 })
 @JsonTypeName("listMyGroupChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListMyGroupChannelsResponse {
   public static final String JSON_PROPERTY_CHANNELS = "channels";
   private List<SendBirdGroupChannel> channels = null;

--- a/src/main/java/org/openapitools/client/model/ListPushConfigurationsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListPushConfigurationsResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListPushConfigurationsResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("listPushConfigurationsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListPushConfigurationsResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<ListPushConfigurationsResponsePushConfigurationsInner> pushConfigurations = null;

--- a/src/main/java/org/openapitools/client/model/ListPushConfigurationsResponsePushConfigurationsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListPushConfigurationsResponsePushConfigurationsInner.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   ListPushConfigurationsResponsePushConfigurationsInner.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("listPushConfigurationsResponse_push_configurations_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListPushConfigurationsResponsePushConfigurationsInner {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;

--- a/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListPushNotificationContentTemplatesResponse.JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES
 })
 @JsonTypeName("listPushNotificationContentTemplatesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListPushNotificationContentTemplatesResponse {
   public static final String JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES = "push_message_templates";
   private List<ListPushNotificationContentTemplatesResponsePushMessageTemplatesInner> pushMessageTemplates = null;

--- a/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponsePushMessageTemplatesInner.java
+++ b/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponsePushMessageTemplatesInner.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ListPushNotificationContentTemplatesResponsePushMessageTemplatesInner.JSON_PROPERTY_TEMPLATE
 })
 @JsonTypeName("listPushNotificationContentTemplatesResponse_push_message_templates_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListPushNotificationContentTemplatesResponsePushMessageTemplatesInner {
   public static final String JSON_PROPERTY_TEMPLATE_NAME = "template_name";
   private String templateName;

--- a/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponsePushMessageTemplatesInnerTemplate.java
+++ b/src/main/java/org/openapitools/client/model/ListPushNotificationContentTemplatesResponsePushMessageTemplatesInnerTemplate.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ListPushNotificationContentTemplatesResponsePushMessageTemplatesInnerTemplate.JSON_PROPERTY_A_D_M_M
 })
 @JsonTypeName("listPushNotificationContentTemplatesResponse_push_message_templates_inner_template")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListPushNotificationContentTemplatesResponsePushMessageTemplatesInnerTemplate {
   public static final String JSON_PROPERTY_M_E_S_G = "MESG";
   private String MESG;

--- a/src/main/java/org/openapitools/client/model/ListReactionsOfMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListReactionsOfMessageResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ListReactionsOfMessageResponse.JSON_PROPERTY_KEY
 })
 @JsonTypeName("listReactionsOfMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListReactionsOfMessageResponse {
   public static final String JSON_PROPERTY_KEY = "key";
   private List<String> key = null;

--- a/src/main/java/org/openapitools/client/model/ListRegistrationOrDeviceTokensResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListRegistrationOrDeviceTokensResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   ListRegistrationOrDeviceTokensResponse.JSON_PROPERTY_USER
 })
 @JsonTypeName("listRegistrationOrDeviceTokensResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListRegistrationOrDeviceTokensResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private List<String> token = null;

--- a/src/main/java/org/openapitools/client/model/ListReportsOnChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsOnChannelByUrlResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListReportsOnChannelByUrlResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listReportsOnChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListReportsOnChannelByUrlResponse {
   public static final String JSON_PROPERTY_REPORT_LOGS = "report_logs";
   private List<ListReportsOnMessageByIdResponseReportLogsInner> reportLogs = null;

--- a/src/main/java/org/openapitools/client/model/ListReportsOnMessageByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsOnMessageByIdResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListReportsOnMessageByIdResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listReportsOnMessageByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListReportsOnMessageByIdResponse {
   public static final String JSON_PROPERTY_REPORT_LOGS = "report_logs";
   private List<ListReportsOnMessageByIdResponseReportLogsInner> reportLogs = null;

--- a/src/main/java/org/openapitools/client/model/ListReportsOnMessageByIdResponseReportLogsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsOnMessageByIdResponseReportLogsInner.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ListReportsOnMessageByIdResponseReportLogsInner.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("listReportsOnMessageByIdResponse_report_logs_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListReportsOnMessageByIdResponseReportLogsInner {
   public static final String JSON_PROPERTY_REPORT_TYPE = "report_type";
   private String reportType;

--- a/src/main/java/org/openapitools/client/model/ListReportsOnUserByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsOnUserByIdResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListReportsOnUserByIdResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listReportsOnUserByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListReportsOnUserByIdResponse {
   public static final String JSON_PROPERTY_REPORT_LOGS = "report_logs";
   private List<ListReportsOnMessageByIdResponseReportLogsInner> reportLogs = null;

--- a/src/main/java/org/openapitools/client/model/ListReportsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListReportsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listReportsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListReportsResponse {
   public static final String JSON_PROPERTY_REPORT_LOGS = "report_logs";
   private List<ListReportsResponseReportLogsInner> reportLogs = null;

--- a/src/main/java/org/openapitools/client/model/ListReportsResponseReportLogsInner.java
+++ b/src/main/java/org/openapitools/client/model/ListReportsResponseReportLogsInner.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ListReportsResponseReportLogsInner.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("listReportsResponse_report_logs_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListReportsResponseReportLogsInner {
   public static final String JSON_PROPERTY_REPORTING_USER = "reporting_user";
   private SendBirdUser reportingUser;

--- a/src/main/java/org/openapitools/client/model/ListSecondaryApiTokensResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListSecondaryApiTokensResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ListSecondaryApiTokensResponse.JSON_PROPERTY_API_TOKENS
 })
 @JsonTypeName("listSecondaryApiTokensResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListSecondaryApiTokensResponse {
   public static final String JSON_PROPERTY_API_TOKENS = "api_tokens";
   private List<ListSecondaryApiTokensResponseApiTokensInner> apiTokens = null;

--- a/src/main/java/org/openapitools/client/model/ListSecondaryApiTokensResponseApiTokensInner.java
+++ b/src/main/java/org/openapitools/client/model/ListSecondaryApiTokensResponseApiTokensInner.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ListSecondaryApiTokensResponseApiTokensInner.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("listSecondaryApiTokensResponse_api_tokens_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListSecondaryApiTokensResponseApiTokensInner {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;

--- a/src/main/java/org/openapitools/client/model/ListUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/ListUsersResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ListUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("listUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ListUsersResponse {
   public static final String JSON_PROPERTY_USERS = "users";
   private List<SendBirdUser> users = null;

--- a/src/main/java/org/openapitools/client/model/MarkAllMessagesAsReadData.java
+++ b/src/main/java/org/openapitools/client/model/MarkAllMessagesAsReadData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   MarkAllMessagesAsReadData.JSON_PROPERTY_CHANNEL_URLS
 })
 @JsonTypeName("markAllMessagesAsReadData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class MarkAllMessagesAsReadData {
   public static final String JSON_PROPERTY_CHANNEL_URLS = "channel_urls";
   private List<String> channelUrls = new ArrayList<>();

--- a/src/main/java/org/openapitools/client/model/ModelFile.java
+++ b/src/main/java/org/openapitools/client/model/ModelFile.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   ModelFile.JSON_PROPERTY_WEBKIT_RELATIVE_PATH
 })
 @JsonTypeName("File")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ModelFile {
   public static final String JSON_PROPERTY_LAST_MODIFIED = "last_modified";
   private BigDecimal lastModified;

--- a/src/main/java/org/openapitools/client/model/MuteInChannelsWithCustomChannelTypesData.java
+++ b/src/main/java/org/openapitools/client/model/MuteInChannelsWithCustomChannelTypesData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   MuteInChannelsWithCustomChannelTypesData.JSON_PROPERTY_CHANNEL_CUSTOM_TYPES
 })
 @JsonTypeName("muteInChannelsWithCustomChannelTypesData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class MuteInChannelsWithCustomChannelTypesData {
   public static final String JSON_PROPERTY_CHANNEL_CUSTOM_TYPES = "channel_custom_types";
   private List<String> channelCustomTypes = new ArrayList<>();

--- a/src/main/java/org/openapitools/client/model/MuteUsersInChannelsWithCustomChannelTypeData.java
+++ b/src/main/java/org/openapitools/client/model/MuteUsersInChannelsWithCustomChannelTypeData.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   MuteUsersInChannelsWithCustomChannelTypeData.JSON_PROPERTY_ON_DEMAND_UPSERT
 })
 @JsonTypeName("muteUsersInChannelsWithCustomChannelTypeData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class MuteUsersInChannelsWithCustomChannelTypeData {
   public static final String JSON_PROPERTY_USER_IDS = "user_ids";
   private List<String> userIds = new ArrayList<>();

--- a/src/main/java/org/openapitools/client/model/OcBanUserData.java
+++ b/src/main/java/org/openapitools/client/model/OcBanUserData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   OcBanUserData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("ocBanUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcBanUserData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/OcBanUserResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcBanUserResponse.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   OcBanUserResponse.JSON_PROPERTY_METADATA
 })
 @JsonTypeName("ocBanUserResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcBanUserResponse {
   public static final String JSON_PROPERTY_START_AT = "start_at";
   private BigDecimal startAt;

--- a/src/main/java/org/openapitools/client/model/OcCreateChannelData.java
+++ b/src/main/java/org/openapitools/client/model/OcCreateChannelData.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   OcCreateChannelData.JSON_PROPERTY_OPERATORS
 })
 @JsonTypeName("ocCreateChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcCreateChannelData {
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;

--- a/src/main/java/org/openapitools/client/model/OcDeleteChannelByUrl200Response.java
+++ b/src/main/java/org/openapitools/client/model/OcDeleteChannelByUrl200Response.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   OcDeleteChannelByUrl200Response.JSON_PROPERTY_ANY_OF
 })
 @JsonTypeName("ocDeleteChannelByUrl_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcDeleteChannelByUrl200Response {
   public static final String JSON_PROPERTY_ANY_OF = "anyOf";
   private String anyOf;

--- a/src/main/java/org/openapitools/client/model/OcFreezeChannelData.java
+++ b/src/main/java/org/openapitools/client/model/OcFreezeChannelData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   OcFreezeChannelData.JSON_PROPERTY_FREEZE
 })
 @JsonTypeName("ocFreezeChannelData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcFreezeChannelData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/OcListBannedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcListBannedUsersResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   OcListBannedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("ocListBannedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcListBannedUsersResponse {
   public static final String JSON_PROPERTY_BANNED_LIST = "banned_list";
   private List<OcListBannedUsersResponseBannedListInner> bannedList = null;

--- a/src/main/java/org/openapitools/client/model/OcListBannedUsersResponseBannedListInner.java
+++ b/src/main/java/org/openapitools/client/model/OcListBannedUsersResponseBannedListInner.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   OcListBannedUsersResponseBannedListInner.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("ocListBannedUsersResponse_banned_list_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcListBannedUsersResponseBannedListInner {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;

--- a/src/main/java/org/openapitools/client/model/OcListChannelsResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcListChannelsResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   OcListChannelsResponse.JSON_PROPERTY_TS
 })
 @JsonTypeName("ocListChannelsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcListChannelsResponse {
   public static final String JSON_PROPERTY_CHANNELS = "channels";
   private List<SendBirdOpenChannel> channels = null;

--- a/src/main/java/org/openapitools/client/model/OcListMutedUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcListMutedUsersResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   OcListMutedUsersResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("ocListMutedUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcListMutedUsersResponse {
   public static final String JSON_PROPERTY_MUTED_LIST = "muted_list";
   private List<SendBirdUser> mutedList = null;

--- a/src/main/java/org/openapitools/client/model/OcListOperatorsResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcListOperatorsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   OcListOperatorsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("ocListOperatorsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcListOperatorsResponse {
   public static final String JSON_PROPERTY_OPERATORS = "operators";
   private List<SendBirdUser> operators = null;

--- a/src/main/java/org/openapitools/client/model/OcListParticipantsResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcListParticipantsResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   OcListParticipantsResponse.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("ocListParticipantsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcListParticipantsResponse {
   public static final String JSON_PROPERTY_PARTICIPANTS = "participants";
   private List<SendBirdUser> participants = null;

--- a/src/main/java/org/openapitools/client/model/OcMuteUserData.java
+++ b/src/main/java/org/openapitools/client/model/OcMuteUserData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   OcMuteUserData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("ocMuteUserData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcMuteUserData {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/openapitools/client/model/OcRegisterOperatorsData.java
+++ b/src/main/java/org/openapitools/client/model/OcRegisterOperatorsData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   OcRegisterOperatorsData.JSON_PROPERTY_OPERATOR_IDS
 })
 @JsonTypeName("ocRegisterOperatorsData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcRegisterOperatorsData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/OcUpdateBanByIdData.java
+++ b/src/main/java/org/openapitools/client/model/OcUpdateBanByIdData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   OcUpdateBanByIdData.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("ocUpdateBanByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcUpdateBanByIdData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/OcUpdateBanByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcUpdateBanByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   OcUpdateBanByIdResponse.JSON_PROPERTY_START_AT
 })
 @JsonTypeName("ocUpdateBanByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcUpdateBanByIdResponse {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;

--- a/src/main/java/org/openapitools/client/model/OcUpdateChannelByUrlData.java
+++ b/src/main/java/org/openapitools/client/model/OcUpdateChannelByUrlData.java
@@ -45,7 +45,7 @@ import org.sendbird.client.JSON;
   OcUpdateChannelByUrlData.JSON_PROPERTY_OPERATORS
 })
 @JsonTypeName("ocUpdateChannelByUrlData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcUpdateChannelByUrlData {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -66,10 +66,10 @@ public class OcUpdateChannelByUrlData {
   private String data;
 
   public static final String JSON_PROPERTY_OPERATOR_IDS = "operator_ids";
-  private List<String> operatorIds = new ArrayList<>();
+  private List<String> operatorIds = null;
 
   public static final String JSON_PROPERTY_OPERATORS = "operators";
-  private List<String> operators = new ArrayList<>();
+  private List<String> operators = null;
 
   public OcUpdateChannelByUrlData() { 
   }
@@ -109,10 +109,10 @@ public class OcUpdateChannelByUrlData {
    * Specifies the channel topic, or the name of the channel. The length is limited to 191 characters.
    * @return name
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "Specifies the channel topic, or the name of the channel. The length is limited to 191 characters.")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Specifies the channel topic, or the name of the channel. The length is limited to 191 characters.")
   @JsonProperty(JSON_PROPERTY_NAME)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public String getName() {
     return name;
@@ -120,7 +120,7 @@ public class OcUpdateChannelByUrlData {
 
 
   @JsonProperty(JSON_PROPERTY_NAME)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }
@@ -135,10 +135,10 @@ public class OcUpdateChannelByUrlData {
    * Specifies the URL of the cover image. The length is limited to 2,048 characters.
    * @return coverUrl
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "Specifies the URL of the cover image. The length is limited to 2,048 characters.")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Specifies the URL of the cover image. The length is limited to 2,048 characters.")
   @JsonProperty(JSON_PROPERTY_COVER_URL)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public String getCoverUrl() {
     return coverUrl;
@@ -146,7 +146,7 @@ public class OcUpdateChannelByUrlData {
 
 
   @JsonProperty(JSON_PROPERTY_COVER_URL)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCoverUrl(String coverUrl) {
     this.coverUrl = coverUrl;
   }
@@ -161,10 +161,10 @@ public class OcUpdateChannelByUrlData {
    * Uploads the file for the channel cover image.
    * @return coverFile
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "Uploads the file for the channel cover image.")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Uploads the file for the channel cover image.")
   @JsonProperty(JSON_PROPERTY_COVER_FILE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public File getCoverFile() {
     return coverFile;
@@ -172,7 +172,7 @@ public class OcUpdateChannelByUrlData {
 
 
   @JsonProperty(JSON_PROPERTY_COVER_FILE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCoverFile(File coverFile) {
     this.coverFile = coverFile;
   }
@@ -187,10 +187,10 @@ public class OcUpdateChannelByUrlData {
    * Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.&lt;br /&gt;&lt;br /&gt; Custom types are also used within Sendbird&#39;s [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.
    * @return customType
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.<br /><br /> Custom types are also used within Sendbird's [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Specifies the custom channel type which is used for channel grouping. The length is limited to 128 characters.<br /><br /> Custom types are also used within Sendbird's [Advanced analytics](/docs/chat/v3/platform-api/guides/advanced-analytics) to segment metrics, which enables the sub-classification of data views.")
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public String getCustomType() {
     return customType;
@@ -198,7 +198,7 @@ public class OcUpdateChannelByUrlData {
 
 
   @JsonProperty(JSON_PROPERTY_CUSTOM_TYPE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCustomType(String customType) {
     this.customType = customType;
   }
@@ -213,10 +213,10 @@ public class OcUpdateChannelByUrlData {
    * Specifies additional channel information such as a long description of the channel or &#x60;JSON&#x60; formatted string.
    * @return data
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "Specifies additional channel information such as a long description of the channel or `JSON` formatted string.")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Specifies additional channel information such as a long description of the channel or `JSON` formatted string.")
   @JsonProperty(JSON_PROPERTY_DATA)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public String getData() {
     return data;
@@ -224,7 +224,7 @@ public class OcUpdateChannelByUrlData {
 
 
   @JsonProperty(JSON_PROPERTY_DATA)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setData(String data) {
     this.data = data;
   }
@@ -236,6 +236,9 @@ public class OcUpdateChannelByUrlData {
   }
 
   public OcUpdateChannelByUrlData addOperatorIdsItem(String operatorIdsItem) {
+    if (this.operatorIds == null) {
+      this.operatorIds = new ArrayList<>();
+    }
     this.operatorIds.add(operatorIdsItem);
     return this;
   }
@@ -244,10 +247,10 @@ public class OcUpdateChannelByUrlData {
    * Specifies an array of one or more user IDs to register as operators of the channel. The maximum allowed number of operators per channel is 100. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.&lt;br/&gt;&lt;br/&gt;  Operators cannot view messages that have been [moderated by](/docs/chat/v3/platform-api/guides/filter-and-moderation) the domain filter or profanity filter. Only the sender will be notified that the message has been blocked.
    * @return operatorIds
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "Specifies an array of one or more user IDs to register as operators of the channel. The maximum allowed number of operators per channel is 100. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.<br/><br/>  Operators cannot view messages that have been [moderated by](/docs/chat/v3/platform-api/guides/filter-and-moderation) the domain filter or profanity filter. Only the sender will be notified that the message has been blocked.")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Specifies an array of one or more user IDs to register as operators of the channel. The maximum allowed number of operators per channel is 100. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.<br/><br/>  Operators cannot view messages that have been [moderated by](/docs/chat/v3/platform-api/guides/filter-and-moderation) the domain filter or profanity filter. Only the sender will be notified that the message has been blocked.")
   @JsonProperty(JSON_PROPERTY_OPERATOR_IDS)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public List<String> getOperatorIds() {
     return operatorIds;
@@ -255,7 +258,7 @@ public class OcUpdateChannelByUrlData {
 
 
   @JsonProperty(JSON_PROPERTY_OPERATOR_IDS)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOperatorIds(List<String> operatorIds) {
     this.operatorIds = operatorIds;
   }
@@ -267,6 +270,9 @@ public class OcUpdateChannelByUrlData {
   }
 
   public OcUpdateChannelByUrlData addOperatorsItem(String operatorsItem) {
+    if (this.operators == null) {
+      this.operators = new ArrayList<>();
+    }
     this.operators.add(operatorsItem);
     return this;
   }
@@ -275,10 +281,10 @@ public class OcUpdateChannelByUrlData {
    * (Deprecated) Specifies the string IDs of the users registered as channel operators. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.
    * @return operators
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "(Deprecated) Specifies the string IDs of the users registered as channel operators. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "(Deprecated) Specifies the string IDs of the users registered as channel operators. Operators can delete any messages in the channel, and can also receive all messages that have been throttled.")
   @JsonProperty(JSON_PROPERTY_OPERATORS)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public List<String> getOperators() {
     return operators;
@@ -286,7 +292,7 @@ public class OcUpdateChannelByUrlData {
 
 
   @JsonProperty(JSON_PROPERTY_OPERATORS)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOperators(List<String> operators) {
     this.operators = operators;
   }

--- a/src/main/java/org/openapitools/client/model/OcViewBanByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcViewBanByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   OcViewBanByIdResponse.JSON_PROPERTY_START_AT
 })
 @JsonTypeName("ocViewBanByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcViewBanByIdResponse {
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;

--- a/src/main/java/org/openapitools/client/model/OcViewMuteByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/OcViewMuteByIdResponse.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   OcViewMuteByIdResponse.JSON_PROPERTY_DESCRIPTION
 })
 @JsonTypeName("ocViewMuteByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OcViewMuteByIdResponse {
   public static final String JSON_PROPERTY_IS_MUTED = "is_muted";
   private Boolean isMuted;

--- a/src/main/java/org/openapitools/client/model/RegisterAndScheduleDataExportData.java
+++ b/src/main/java/org/openapitools/client/model/RegisterAndScheduleDataExportData.java
@@ -49,7 +49,7 @@ import org.sendbird.client.JSON;
   RegisterAndScheduleDataExportData.JSON_PROPERTY_NEIGHBORING_MESSAGE_LIMIT
 })
 @JsonTypeName("registerAndScheduleDataExportData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RegisterAndScheduleDataExportData {
   public static final String JSON_PROPERTY_START_TS = "start_ts";
   private Integer startTs;

--- a/src/main/java/org/openapitools/client/model/RegisterAndScheduleDataExportResponse.java
+++ b/src/main/java/org/openapitools/client/model/RegisterAndScheduleDataExportResponse.java
@@ -52,7 +52,7 @@ import org.sendbird.client.JSON;
   RegisterAndScheduleDataExportResponse.JSON_PROPERTY_USER_IDS
 })
 @JsonTypeName("registerAndScheduleDataExportResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RegisterAndScheduleDataExportResponse {
   public static final String JSON_PROPERTY_CHANNEL_CUSTOM_TYPES = "channel_custom_types";
   private List<String> channelCustomTypes = null;

--- a/src/main/java/org/openapitools/client/model/RegisterAsOperatorToChannelsWithCustomChannelTypesData.java
+++ b/src/main/java/org/openapitools/client/model/RegisterAsOperatorToChannelsWithCustomChannelTypesData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   RegisterAsOperatorToChannelsWithCustomChannelTypesData.JSON_PROPERTY_CHANNEL_CUSTOM_TYPES
 })
 @JsonTypeName("registerAsOperatorToChannelsWithCustomChannelTypesData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RegisterAsOperatorToChannelsWithCustomChannelTypesData {
   public static final String JSON_PROPERTY_CHANNEL_CUSTOM_TYPES = "channel_custom_types";
   private List<String> channelCustomTypes = new ArrayList<>();

--- a/src/main/java/org/openapitools/client/model/RegisterGdprRequestData.java
+++ b/src/main/java/org/openapitools/client/model/RegisterGdprRequestData.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   RegisterGdprRequestData.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("registerGdprRequestData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RegisterGdprRequestData {
   public static final String JSON_PROPERTY_ACTION = "action";
   private String action;

--- a/src/main/java/org/openapitools/client/model/RegisterGdprRequestResponse.java
+++ b/src/main/java/org/openapitools/client/model/RegisterGdprRequestResponse.java
@@ -44,7 +44,7 @@ import org.sendbird.client.JSON;
   RegisterGdprRequestResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("registerGdprRequestResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RegisterGdprRequestResponse {
   public static final String JSON_PROPERTY_REQUEST_ID = "request_id";
   private String requestId;

--- a/src/main/java/org/openapitools/client/model/RemovePushConfigurationByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/RemovePushConfigurationByIdResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   RemovePushConfigurationByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("removePushConfigurationByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RemovePushConfigurationByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<String> pushConfigurations = null;

--- a/src/main/java/org/openapitools/client/model/RemoveReactionFromAMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/RemoveReactionFromAMessageResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   RemoveReactionFromAMessageResponse.JSON_PROPERTY_OPERATION
 })
 @JsonTypeName("removeReactionFromAMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RemoveReactionFromAMessageResponse {
   public static final String JSON_PROPERTY_REACTION = "reaction";
   private String reaction;

--- a/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenByTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenByTokenResponse.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.ArrayList;
-import java.util.List;
 import org.openapitools.client.model.SendBirdUser;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.sendbird.client.JSON;
@@ -39,10 +37,10 @@ import org.sendbird.client.JSON;
   RemoveRegistrationOrDeviceTokenByTokenResponse.JSON_PROPERTY_USER
 })
 @JsonTypeName("removeRegistrationOrDeviceTokenByTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RemoveRegistrationOrDeviceTokenByTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
-  private List<String> token = null;
+  private String token;
 
   public static final String JSON_PROPERTY_USER = "user";
   private SendBirdUser user;
@@ -50,16 +48,8 @@ public class RemoveRegistrationOrDeviceTokenByTokenResponse {
   public RemoveRegistrationOrDeviceTokenByTokenResponse() { 
   }
 
-  public RemoveRegistrationOrDeviceTokenByTokenResponse token(List<String> token) {
+  public RemoveRegistrationOrDeviceTokenByTokenResponse token(String token) {
     this.token = token;
-    return this;
-  }
-
-  public RemoveRegistrationOrDeviceTokenByTokenResponse addTokenItem(String tokenItem) {
-    if (this.token == null) {
-      this.token = new ArrayList<>();
-    }
-    this.token.add(tokenItem);
     return this;
   }
 
@@ -72,14 +62,14 @@ public class RemoveRegistrationOrDeviceTokenByTokenResponse {
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public List<String> getToken() {
+  public String getToken() {
     return token;
   }
 
 
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setToken(List<String> token) {
+  public void setToken(String token) {
     this.token = token;
   }
 

--- a/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenFromOwnerByTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenFromOwnerByTokenResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   RemoveRegistrationOrDeviceTokenFromOwnerByTokenResponse.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("removeRegistrationOrDeviceTokenFromOwnerByTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RemoveRegistrationOrDeviceTokenFromOwnerByTokenResponse {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/RemoveRegistrationOrDeviceTokenResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   RemoveRegistrationOrDeviceTokenResponse.JSON_PROPERTY_USER
 })
 @JsonTypeName("removeRegistrationOrDeviceTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RemoveRegistrationOrDeviceTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private List<String> token = null;

--- a/src/main/java/org/openapitools/client/model/ReportChannelByUrlData.java
+++ b/src/main/java/org/openapitools/client/model/ReportChannelByUrlData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ReportChannelByUrlData.JSON_PROPERTY_REPORT_DESCRIPTION
 })
 @JsonTypeName("reportChannelByUrlData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ReportChannelByUrlData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;

--- a/src/main/java/org/openapitools/client/model/ReportChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/ReportChannelByUrlResponse.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ReportChannelByUrlResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("reportChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ReportChannelByUrlResponse {
   public static final String JSON_PROPERTY_REPORT_TYPE = "report_type";
   private String reportType;

--- a/src/main/java/org/openapitools/client/model/ReportMessageByIdData.java
+++ b/src/main/java/org/openapitools/client/model/ReportMessageByIdData.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   ReportMessageByIdData.JSON_PROPERTY_REPORT_DESCRIPTION
 })
 @JsonTypeName("reportMessageByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ReportMessageByIdData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;

--- a/src/main/java/org/openapitools/client/model/ReportMessageByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ReportMessageByIdResponse.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ReportMessageByIdResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("reportMessageByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ReportMessageByIdResponse {
   public static final String JSON_PROPERTY_REPORT_TYPE = "report_type";
   private String reportType;

--- a/src/main/java/org/openapitools/client/model/ReportUserByIdData.java
+++ b/src/main/java/org/openapitools/client/model/ReportUserByIdData.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   ReportUserByIdData.JSON_PROPERTY_REPORT_DESCRIPTION
 })
 @JsonTypeName("reportUserByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ReportUserByIdData {
   public static final String JSON_PROPERTY_OFFENDING_USER_ID = "offending_user_id";
   private String offendingUserId;

--- a/src/main/java/org/openapitools/client/model/ReportUserByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ReportUserByIdResponse.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   ReportUserByIdResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("reportUserByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ReportUserByIdResponse {
   public static final String JSON_PROPERTY_REPORT_TYPE = "report_type";
   private String reportType;

--- a/src/main/java/org/openapitools/client/model/ResetPushPreferencesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ResetPushPreferencesResponse.java
@@ -51,7 +51,7 @@ import org.sendbird.client.JSON;
   ResetPushPreferencesResponse.JSON_PROPERTY_PUSH_TRIGGER_OPTION
 })
 @JsonTypeName("resetPushPreferencesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ResetPushPreferencesResponse {
   public static final String JSON_PROPERTY_SNOOZE_START_TS = "snooze_start_ts";
   private String snoozeStartTs;

--- a/src/main/java/org/openapitools/client/model/RetrieveAdvancedAnalyticsMetricsResponse.java
+++ b/src/main/java/org/openapitools/client/model/RetrieveAdvancedAnalyticsMetricsResponse.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   RetrieveAdvancedAnalyticsMetricsResponse.JSON_PROPERTY_CUSTOM_MESSAGE_TYPE
 })
 @JsonTypeName("retrieveAdvancedAnalyticsMetricsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RetrieveAdvancedAnalyticsMetricsResponse {
   public static final String JSON_PROPERTY_SEGMENTS = "segments";
   private String segments;

--- a/src/main/java/org/openapitools/client/model/RetrieveIpWhitelistResponse.java
+++ b/src/main/java/org/openapitools/client/model/RetrieveIpWhitelistResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   RetrieveIpWhitelistResponse.JSON_PROPERTY_IP_WHITELIST_ADDRESSES
 })
 @JsonTypeName("retrieveIpWhitelistResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RetrieveIpWhitelistResponse {
   public static final String JSON_PROPERTY_IP_WHITELIST_ADDRESSES = "ip_whitelist_addresses";
   private List<String> ipWhitelistAddresses = null;

--- a/src/main/java/org/openapitools/client/model/RetrieveListOfSubscribedEventsResponse.java
+++ b/src/main/java/org/openapitools/client/model/RetrieveListOfSubscribedEventsResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   RetrieveListOfSubscribedEventsResponse.JSON_PROPERTY_WEBHOOK
 })
 @JsonTypeName("retrieveListOfSubscribedEventsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RetrieveListOfSubscribedEventsResponse {
   public static final String JSON_PROPERTY_WEBHOOK = "webhook";
   private RetrieveListOfSubscribedEventsResponseWebhook webhook;

--- a/src/main/java/org/openapitools/client/model/RetrieveListOfSubscribedEventsResponseWebhook.java
+++ b/src/main/java/org/openapitools/client/model/RetrieveListOfSubscribedEventsResponseWebhook.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   RetrieveListOfSubscribedEventsResponseWebhook.JSON_PROPERTY_INCLUDE_UNREAD_COUNT
 })
 @JsonTypeName("retrieveListOfSubscribedEventsResponse_webhook")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RetrieveListOfSubscribedEventsResponseWebhook {
   public static final String JSON_PROPERTY_ENABLED = "enabled";
   private Boolean enabled;

--- a/src/main/java/org/openapitools/client/model/RevokeSecondaryApiTokenByTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/RevokeSecondaryApiTokenByTokenResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   RevokeSecondaryApiTokenByTokenResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("revokeSecondaryApiTokenByTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class RevokeSecondaryApiTokenByTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;

--- a/src/main/java/org/openapitools/client/model/SBObject.java
+++ b/src/main/java/org/openapitools/client/model/SBObject.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
 @JsonPropertyOrder({
   SBObject.JSON_PROPERTY_CONSTRUCTOR
 })
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SBObject {
   public static final String JSON_PROPERTY_CONSTRUCTOR = "constructor";
   private Function constructor;

--- a/src/main/java/org/openapitools/client/model/ScheduleAnnouncementData.java
+++ b/src/main/java/org/openapitools/client/model/ScheduleAnnouncementData.java
@@ -61,7 +61,7 @@ import org.sendbird.client.JSON;
   ScheduleAnnouncementData.JSON_PROPERTY_ASSIGN_SENDER_AS_CHANNEL_INVITER
 })
 @JsonTypeName("scheduleAnnouncementData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ScheduleAnnouncementData {
   public static final String JSON_PROPERTY_MESSAGE = "message";
   private ScheduleAnnouncementDataMessage message;

--- a/src/main/java/org/openapitools/client/model/ScheduleAnnouncementDataMessage.java
+++ b/src/main/java/org/openapitools/client/model/ScheduleAnnouncementDataMessage.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ScheduleAnnouncementDataMessage.JSON_PROPERTY_CONTENT
 })
 @JsonTypeName("scheduleAnnouncementData_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ScheduleAnnouncementDataMessage {
   public static final String JSON_PROPERTY_TYPE = "type";
   private String type;

--- a/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponse.java
+++ b/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponse.java
@@ -55,7 +55,7 @@ import org.sendbird.client.JSON;
   ScheduleAnnouncementResponse.JSON_PROPERTY_OPEN_RATE
 })
 @JsonTypeName("scheduleAnnouncementResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ScheduleAnnouncementResponse {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;

--- a/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponseCreateChannelOptions.java
+++ b/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponseCreateChannelOptions.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ScheduleAnnouncementResponseCreateChannelOptions.JSON_PROPERTY_CUSTOM_TYPE
 })
 @JsonTypeName("scheduleAnnouncementResponse_create_channel_options")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ScheduleAnnouncementResponseCreateChannelOptions {
   public static final String JSON_PROPERTY_DISTINCT = "distinct";
   private Boolean distinct;

--- a/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponseMessage.java
+++ b/src/main/java/org/openapitools/client/model/ScheduleAnnouncementResponseMessage.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   ScheduleAnnouncementResponseMessage.JSON_PROPERTY_DATA
 })
 @JsonTypeName("scheduleAnnouncementResponse_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ScheduleAnnouncementResponseMessage {
   public static final String JSON_PROPERTY_TYPE = "type";
   private String type;

--- a/src/main/java/org/openapitools/client/model/SendBirdAdminMessage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdAdminMessage.java
@@ -73,7 +73,7 @@ import org.sendbird.client.JSON;
   SendBirdAdminMessage.JSON_PROPERTY_UPDATED_AT
 })
 @JsonTypeName("SendBird.AdminMessage")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdAdminMessage {
   public static final String JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS = "apple_critical_alert_options";
   private SendBirdAppleCriticalAlertOptions appleCriticalAlertOptions;

--- a/src/main/java/org/openapitools/client/model/SendBirdAppleCriticalAlertOptions.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdAppleCriticalAlertOptions.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SendBirdAppleCriticalAlertOptions.JSON_PROPERTY_VOLUME
 })
 @JsonTypeName("SendBird.AppleCriticalAlertOptions")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdAppleCriticalAlertOptions {
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;

--- a/src/main/java/org/openapitools/client/model/SendBirdAutoEventMessageSettings.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdAutoEventMessageSettings.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   SendBirdAutoEventMessageSettings.JSON_PROPERTY_AUTO_EVENT_MESSAGE
 })
 @JsonTypeName("SendBird.AutoEventMessageSettings")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdAutoEventMessageSettings {
   public static final String JSON_PROPERTY_AUTO_EVENT_MESSAGE = "auto_event_message";
   private ConfigureAutoEventDataAutoEventMessage autoEventMessage;

--- a/src/main/java/org/openapitools/client/model/SendBirdBaseChannel.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBaseChannel.java
@@ -40,12 +40,11 @@ import org.sendbird.client.JSON;
   SendBirdBaseChannel.JSON_PROPERTY_CUSTOM_TYPE,
   SendBirdBaseChannel.JSON_PROPERTY_DATA,
   SendBirdBaseChannel.JSON_PROPERTY_IS_EPHEMERAL,
-  SendBirdBaseChannel.JSON_PROPERTY_IS_FROZEN,
   SendBirdBaseChannel.JSON_PROPERTY_NAME,
   SendBirdBaseChannel.JSON_PROPERTY_URL
 })
 @JsonTypeName("SendBird.BaseChannel")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdBaseChannel {
   public static final String JSON_PROPERTY_COVER_URL = "cover_url";
   private String coverUrl;
@@ -64,9 +63,6 @@ public class SendBirdBaseChannel {
 
   public static final String JSON_PROPERTY_IS_EPHEMERAL = "is_ephemeral";
   private Boolean isEphemeral;
-
-  public static final String JSON_PROPERTY_IS_FROZEN = "is_frozen";
-  private Boolean isFrozen;
 
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;
@@ -233,32 +229,6 @@ public class SendBirdBaseChannel {
   }
 
 
-  public SendBirdBaseChannel isFrozen(Boolean isFrozen) {
-    this.isFrozen = isFrozen;
-    return this;
-  }
-
-   /**
-   * Get isFrozen
-   * @return isFrozen
-  **/
-  @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_IS_FROZEN)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public Boolean getIsFrozen() {
-    return isFrozen;
-  }
-
-
-  @JsonProperty(JSON_PROPERTY_IS_FROZEN)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setIsFrozen(Boolean isFrozen) {
-    this.isFrozen = isFrozen;
-  }
-
-
   public SendBirdBaseChannel name(String name) {
     this.name = name;
     return this;
@@ -329,14 +299,13 @@ public class SendBirdBaseChannel {
         Objects.equals(this.customType, sendBirdBaseChannel.customType) &&
         Objects.equals(this.data, sendBirdBaseChannel.data) &&
         Objects.equals(this.isEphemeral, sendBirdBaseChannel.isEphemeral) &&
-        Objects.equals(this.isFrozen, sendBirdBaseChannel.isFrozen) &&
         Objects.equals(this.name, sendBirdBaseChannel.name) &&
         Objects.equals(this.url, sendBirdBaseChannel.url);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(coverUrl, createdAt, creator, customType, data, isEphemeral, isFrozen, name, url);
+    return Objects.hash(coverUrl, createdAt, creator, customType, data, isEphemeral, name, url);
   }
 
   @Override
@@ -349,7 +318,6 @@ public class SendBirdBaseChannel {
     sb.append("    customType: ").append(toIndentedString(customType)).append("\n");
     sb.append("    data: ").append(toIndentedString(data)).append("\n");
     sb.append("    isEphemeral: ").append(toIndentedString(isEphemeral)).append("\n");
-    sb.append("    isFrozen: ").append(toIndentedString(isFrozen)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    url: ").append(toIndentedString(url)).append("\n");
     sb.append("}");

--- a/src/main/java/org/openapitools/client/model/SendBirdBaseMessageInstance.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBaseMessageInstance.java
@@ -72,7 +72,7 @@ import org.sendbird.client.JSON;
   SendBirdBaseMessageInstance.JSON_PROPERTY_UPDATED_AT
 })
 @JsonTypeName("SendBird.BaseMessageInstance")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdBaseMessageInstance {
   public static final String JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS = "apple_critical_alert_options";
   private SendBirdAppleCriticalAlertOptions appleCriticalAlertOptions;

--- a/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   SendBirdBotsMessageResponse.JSON_PROPERTY_MESSAGE
 })
 @JsonTypeName("SendBird.BotsMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdBotsMessageResponse {
   public static final String JSON_PROPERTY_MESSAGE = "message";
   private SendBirdBotsMessageResponseMessage message;

--- a/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessage.java
@@ -62,7 +62,7 @@ import org.sendbird.client.JSON;
   SendBirdBotsMessageResponseMessage.JSON_PROPERTY_EXTENDED_MESSAGE_PAYLOAD
 })
 @JsonTypeName("SendBird_BotsMessageResponse_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdBotsMessageResponseMessage {
   public static final String JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS = "message_survival_seconds";
   private BigDecimal messageSurvivalSeconds;

--- a/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessageExtendedMessagePayload.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessageExtendedMessagePayload.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdBotsMessageResponseMessageExtendedMessagePayload.JSON_PROPERTY_CUSTOM_VIEW
 })
 @JsonTypeName("SendBird_BotsMessageResponse_message_extended_message_payload")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdBotsMessageResponseMessageExtendedMessagePayload {
   public static final String JSON_PROPERTY_SUGGESTED_REPLIES = "suggested_replies";
   private List<String> suggestedReplies = null;

--- a/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessageMessageEvents.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdBotsMessageResponseMessageMessageEvents.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdBotsMessageResponseMessageMessageEvents.JSON_PROPERTY_UPDATE_LAST_MESSAGE
 })
 @JsonTypeName("SendBird_BotsMessageResponse_message_message_events")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdBotsMessageResponseMessageMessageEvents {
   public static final String JSON_PROPERTY_SEND_PUSH_NOTIFICATION = "send_push_notification";
   private String sendPushNotification;

--- a/src/main/java/org/openapitools/client/model/SendBirdChannelResponse.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdChannelResponse.java
@@ -69,7 +69,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.sendbird.client.JSON;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 @JsonDeserialize(using=SendBirdChannelResponse.SendBirdChannelResponseDeserializer.class)
 @JsonSerialize(using = SendBirdChannelResponse.SendBirdChannelResponseSerializer.class)
 public class SendBirdChannelResponse extends AbstractOpenApiSchema {

--- a/src/main/java/org/openapitools/client/model/SendBirdEmoji.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdEmoji.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   SendBirdEmoji.JSON_PROPERTY_URL
 })
 @JsonTypeName("SendBird.Emoji")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdEmoji {
   public static final String JSON_PROPERTY_KEY = "key";
   private String key;

--- a/src/main/java/org/openapitools/client/model/SendBirdEmojiCategory.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdEmojiCategory.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   SendBirdEmojiCategory.JSON_PROPERTY_URL
 })
 @JsonTypeName("SendBird.EmojiCategory")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdEmojiCategory {
   public static final String JSON_PROPERTY_EMOJIS = "emojis";
   private List<SendBirdEmoji> emojis = null;

--- a/src/main/java/org/openapitools/client/model/SendBirdFile.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdFile.java
@@ -44,7 +44,7 @@ import org.sendbird.client.JSON;
   SendBirdFile.JSON_PROPERTY_REQUIRE_AUTH
 })
 @JsonTypeName("SendBird.File")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdFile {
   public static final String JSON_PROPERTY_URL = "url";
   private String url;

--- a/src/main/java/org/openapitools/client/model/SendBirdFileMessageParams.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdFileMessageParams.java
@@ -59,7 +59,7 @@ import org.sendbird.client.JSON;
   SendBirdFileMessageParams.JSON_PROPERTY_THUMBNAIL_SIZES
 })
 @JsonTypeName("SendBird.FileMessageParams")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdFileMessageParams {
   public static final String JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS = "apple_critical_alert_options";
   private SendBirdAppleCriticalAlertOptions appleCriticalAlertOptions;

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannel.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannel.java
@@ -67,7 +67,6 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannel.JSON_PROPERTY_IS_DISCOVERABLE,
   SendBirdGroupChannel.JSON_PROPERTY_IS_DISTINCT,
   SendBirdGroupChannel.JSON_PROPERTY_IS_EPHEMERAL,
-  SendBirdGroupChannel.JSON_PROPERTY_IS_FROZEN,
   SendBirdGroupChannel.JSON_PROPERTY_IS_HIDDEN,
   SendBirdGroupChannel.JSON_PROPERTY_IS_PUBLIC,
   SendBirdGroupChannel.JSON_PROPERTY_IS_PUSH_ENABLED,
@@ -95,7 +94,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannel.JSON_PROPERTY_READ_RECEIPT
 })
 @JsonTypeName("SendBird.GroupChannel")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdGroupChannel {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;
@@ -190,9 +189,6 @@ public class SendBirdGroupChannel {
 
   public static final String JSON_PROPERTY_IS_EPHEMERAL = "is_ephemeral";
   private Boolean isEphemeral;
-
-  public static final String JSON_PROPERTY_IS_FROZEN = "is_frozen";
-  private Boolean isFrozen;
 
   public static final String JSON_PROPERTY_IS_HIDDEN = "is_hidden";
   private Boolean isHidden;
@@ -922,32 +918,6 @@ public class SendBirdGroupChannel {
   }
 
 
-  public SendBirdGroupChannel isFrozen(Boolean isFrozen) {
-    this.isFrozen = isFrozen;
-    return this;
-  }
-
-   /**
-   * Get isFrozen
-   * @return isFrozen
-  **/
-  @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_IS_FROZEN)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public Boolean getIsFrozen() {
-    return isFrozen;
-  }
-
-
-  @JsonProperty(JSON_PROPERTY_IS_FROZEN)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setIsFrozen(Boolean isFrozen) {
-    this.isFrozen = isFrozen;
-  }
-
-
   public SendBirdGroupChannel isHidden(Boolean isHidden) {
     this.isHidden = isHidden;
     return this;
@@ -1661,7 +1631,6 @@ public class SendBirdGroupChannel {
         Objects.equals(this.isDiscoverable, sendBirdGroupChannel.isDiscoverable) &&
         Objects.equals(this.isDistinct, sendBirdGroupChannel.isDistinct) &&
         Objects.equals(this.isEphemeral, sendBirdGroupChannel.isEphemeral) &&
-        Objects.equals(this.isFrozen, sendBirdGroupChannel.isFrozen) &&
         Objects.equals(this.isHidden, sendBirdGroupChannel.isHidden) &&
         Objects.equals(this.isPublic, sendBirdGroupChannel.isPublic) &&
         Objects.equals(this.isPushEnabled, sendBirdGroupChannel.isPushEnabled) &&
@@ -1695,7 +1664,7 @@ public class SendBirdGroupChannel {
 
   @Override
   public int hashCode() {
-    return Objects.hash(channelUrl, coverUrl, createdAt, hashCodeNullable(createdBy), creator, customType, data, disappearingMessage, freeze, ignoreProfanityFilter, hiddenState, invitedAt, inviter, isAccessCodeRequired, isBroadcast, isCreated, isDiscoverable, isDistinct, isEphemeral, isFrozen, isHidden, isPublic, isPushEnabled, isSuper, joinedAt, joinedMemberCount, hashCodeNullable(lastMessage), maxLengthMessage, memberCount, members, messageOffsetTimestamp, messageSurvivalSeconds, myCountPreference, myLastRead, myMemberState, myMutedState, myPushTriggerOption, myRole, name, operators, smsFallback, unreadMentionCount, unreadMessageCount, channel, readReceipt);
+    return Objects.hash(channelUrl, coverUrl, createdAt, hashCodeNullable(createdBy), creator, customType, data, disappearingMessage, freeze, ignoreProfanityFilter, hiddenState, invitedAt, inviter, isAccessCodeRequired, isBroadcast, isCreated, isDiscoverable, isDistinct, isEphemeral, isHidden, isPublic, isPushEnabled, isSuper, joinedAt, joinedMemberCount, hashCodeNullable(lastMessage), maxLengthMessage, memberCount, members, messageOffsetTimestamp, messageSurvivalSeconds, myCountPreference, myLastRead, myMemberState, myMutedState, myPushTriggerOption, myRole, name, operators, smsFallback, unreadMentionCount, unreadMessageCount, channel, readReceipt);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -1728,7 +1697,6 @@ public class SendBirdGroupChannel {
     sb.append("    isDiscoverable: ").append(toIndentedString(isDiscoverable)).append("\n");
     sb.append("    isDistinct: ").append(toIndentedString(isDistinct)).append("\n");
     sb.append("    isEphemeral: ").append(toIndentedString(isEphemeral)).append("\n");
-    sb.append("    isFrozen: ").append(toIndentedString(isFrozen)).append("\n");
     sb.append("    isHidden: ").append(toIndentedString(isHidden)).append("\n");
     sb.append("    isPublic: ").append(toIndentedString(isPublic)).append("\n");
     sb.append("    isPushEnabled: ").append(toIndentedString(isPushEnabled)).append("\n");

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelChannel.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelChannel.java
@@ -43,7 +43,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannelChannel.JSON_PROPERTY_MEMBER_COUNT
 })
 @JsonTypeName("SendBird_GroupChannel_channel")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdGroupChannelChannel {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelCollection.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelCollection.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannelCollection.JSON_PROPERTY_HAS_MORE
 })
 @JsonTypeName("SendBird.GroupChannelCollection")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdGroupChannelCollection {
   public static final String JSON_PROPERTY_CHANNEL_LIST = "channel_list";
   private List<SendBirdGroupChannel> channelList = null;

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelCreatedBy.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelCreatedBy.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannelCreatedBy.JSON_PROPERTY_PROFILE_URL
 })
 @JsonTypeName("SendBird_GroupChannel_created_by")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdGroupChannelCreatedBy {
   public static final String JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE = "require_auth_for_profile_image";
   private Boolean requireAuthForProfileImage;

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelDisappearingMessage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelDisappearingMessage.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannelDisappearingMessage.JSON_PROPERTY_IS_TRIGGERED_BY_MESSAGE_READ
 })
 @JsonTypeName("SendBird_GroupChannel_disappearing_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdGroupChannelDisappearingMessage {
   public static final String JSON_PROPERTY_MESSAGE_SURVIVAL_SECONDS = "message_survival_seconds";
   private BigDecimal messageSurvivalSeconds;

--- a/src/main/java/org/openapitools/client/model/SendBirdGroupChannelSmsFallback.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdGroupChannelSmsFallback.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBirdGroupChannelSmsFallback.JSON_PROPERTY_EXCLUDE_USER_IDS
 })
 @JsonTypeName("SendBird_GroupChannel_sms_fallback")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdGroupChannelSmsFallback {
   public static final String JSON_PROPERTY_WAIT_SECONDS = "wait_seconds";
   private BigDecimal waitSeconds;

--- a/src/main/java/org/openapitools/client/model/SendBirdMember.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdMember.java
@@ -62,7 +62,7 @@ import org.sendbird.client.JSON;
   SendBirdMember.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("SendBird.Member")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdMember {
   public static final String JSON_PROPERTY_CONNECTION_STATUS = "connection_status";
   private String connectionStatus;

--- a/src/main/java/org/openapitools/client/model/SendBirdMessageMetaArray.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdMessageMetaArray.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdMessageMetaArray.JSON_PROPERTY_VALUE
 })
 @JsonTypeName("SendBird.MessageMetaArray")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdMessageMetaArray {
   public static final String JSON_PROPERTY_KEY = "key";
   private String key;

--- a/src/main/java/org/openapitools/client/model/SendBirdMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdMessageResponse.java
@@ -67,7 +67,7 @@ import org.sendbird.client.JSON;
   SendBirdMessageResponse.JSON_PROPERTY_IS_REPLY_TO_CHANNEL
 })
 @JsonTypeName("SendBird.MessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdMessageResponse {
   public static final String JSON_PROPERTY_REQUIRE_AUTH = "require_auth";
   private Boolean requireAuth;

--- a/src/main/java/org/openapitools/client/model/SendBirdMessageResponseMentionedUsersInner.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdMessageResponseMentionedUsersInner.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBirdMessageResponseMentionedUsersInner.JSON_PROPERTY_METADATA
 })
 @JsonTypeName("SendBird_MessageResponse_mentioned_users_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdMessageResponseMentionedUsersInner {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/openapitools/client/model/SendBirdMessageResponseUser.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdMessageResponseUser.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   SendBirdMessageResponseUser.JSON_PROPERTY_METADATA
 })
 @JsonTypeName("SendBird_MessageResponse_user")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdMessageResponseUser {
   public static final String JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE = "require_auth_for_profile_image";
   private Boolean requireAuthForProfileImage;

--- a/src/main/java/org/openapitools/client/model/SendBirdOGImage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdOGImage.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   SendBirdOGImage.JSON_PROPERTY_WIDTH
 })
 @JsonTypeName("SendBird.OGImage")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdOGImage {
   public static final String JSON_PROPERTY_ALT = "alt";
   private String alt;

--- a/src/main/java/org/openapitools/client/model/SendBirdOGMetaData.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdOGMetaData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBirdOGMetaData.JSON_PROPERTY_URL
 })
 @JsonTypeName("SendBird.OGMetaData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdOGMetaData {
   public static final String JSON_PROPERTY_DEFAULT_IMAGE = "default_image";
   private SendBirdOGImage defaultImage;

--- a/src/main/java/org/openapitools/client/model/SendBirdOpenChannel.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdOpenChannel.java
@@ -45,14 +45,13 @@ import org.sendbird.client.JSON;
   SendBirdOpenChannel.JSON_PROPERTY_DATA,
   SendBirdOpenChannel.JSON_PROPERTY_IS_DYNAMIC_PARTITIONED,
   SendBirdOpenChannel.JSON_PROPERTY_IS_EPHEMERAL,
-  SendBirdOpenChannel.JSON_PROPERTY_IS_FROZEN,
   SendBirdOpenChannel.JSON_PROPERTY_MAX_LENGTH_MESSAGE,
   SendBirdOpenChannel.JSON_PROPERTY_OPERATORS,
   SendBirdOpenChannel.JSON_PROPERTY_PARTICIPANT_COUNT,
   SendBirdOpenChannel.JSON_PROPERTY_FREEZE
 })
 @JsonTypeName("SendBird.OpenChannel")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdOpenChannel {
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;
@@ -80,9 +79,6 @@ public class SendBirdOpenChannel {
 
   public static final String JSON_PROPERTY_IS_EPHEMERAL = "is_ephemeral";
   private Boolean isEphemeral;
-
-  public static final String JSON_PROPERTY_IS_FROZEN = "is_frozen";
-  private Boolean isFrozen;
 
   public static final String JSON_PROPERTY_MAX_LENGTH_MESSAGE = "max_length_message";
   private BigDecimal maxLengthMessage;
@@ -333,32 +329,6 @@ public class SendBirdOpenChannel {
   }
 
 
-  public SendBirdOpenChannel isFrozen(Boolean isFrozen) {
-    this.isFrozen = isFrozen;
-    return this;
-  }
-
-   /**
-   * Get isFrozen
-   * @return isFrozen
-  **/
-  @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_IS_FROZEN)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public Boolean getIsFrozen() {
-    return isFrozen;
-  }
-
-
-  @JsonProperty(JSON_PROPERTY_IS_FROZEN)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setIsFrozen(Boolean isFrozen) {
-    this.isFrozen = isFrozen;
-  }
-
-
   public SendBirdOpenChannel maxLengthMessage(BigDecimal maxLengthMessage) {
     this.maxLengthMessage = maxLengthMessage;
     return this;
@@ -492,7 +462,6 @@ public class SendBirdOpenChannel {
         Objects.equals(this.data, sendBirdOpenChannel.data) &&
         Objects.equals(this.isDynamicPartitioned, sendBirdOpenChannel.isDynamicPartitioned) &&
         Objects.equals(this.isEphemeral, sendBirdOpenChannel.isEphemeral) &&
-        Objects.equals(this.isFrozen, sendBirdOpenChannel.isFrozen) &&
         Objects.equals(this.maxLengthMessage, sendBirdOpenChannel.maxLengthMessage) &&
         Objects.equals(this.operators, sendBirdOpenChannel.operators) &&
         Objects.equals(this.participantCount, sendBirdOpenChannel.participantCount) &&
@@ -501,7 +470,7 @@ public class SendBirdOpenChannel {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, customType, channelUrl, createdAt, coverUrl, creator, data, isDynamicPartitioned, isEphemeral, isFrozen, maxLengthMessage, operators, participantCount, freeze);
+    return Objects.hash(name, customType, channelUrl, createdAt, coverUrl, creator, data, isDynamicPartitioned, isEphemeral, maxLengthMessage, operators, participantCount, freeze);
   }
 
   @Override
@@ -517,7 +486,6 @@ public class SendBirdOpenChannel {
     sb.append("    data: ").append(toIndentedString(data)).append("\n");
     sb.append("    isDynamicPartitioned: ").append(toIndentedString(isDynamicPartitioned)).append("\n");
     sb.append("    isEphemeral: ").append(toIndentedString(isEphemeral)).append("\n");
-    sb.append("    isFrozen: ").append(toIndentedString(isFrozen)).append("\n");
     sb.append("    maxLengthMessage: ").append(toIndentedString(maxLengthMessage)).append("\n");
     sb.append("    operators: ").append(toIndentedString(operators)).append("\n");
     sb.append("    participantCount: ").append(toIndentedString(participantCount)).append("\n");

--- a/src/main/java/org/openapitools/client/model/SendBirdParentMessageInfo.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdParentMessageInfo.java
@@ -46,7 +46,7 @@ import org.sendbird.client.JSON;
   SendBirdParentMessageInfo.JSON_PROPERTY_FILES
 })
 @JsonTypeName("SendBird.ParentMessageInfo")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdParentMessageInfo {
   public static final String JSON_PROPERTY_CUSTOM_TYPE = "custom_type";
   private String customType;

--- a/src/main/java/org/openapitools/client/model/SendBirdPlugin.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdPlugin.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SendBirdPlugin.JSON_PROPERTY_VENDOR
 })
 @JsonTypeName("SendBird.Plugin")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdPlugin {
   public static final String JSON_PROPERTY_DETAIL = "detail";
   private Object detail;

--- a/src/main/java/org/openapitools/client/model/SendBirdPoll.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdPoll.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBirdPoll.JSON_PROPERTY_TITLE
 })
 @JsonTypeName("SendBird.Poll")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdPoll {
   public static final String JSON_PROPERTY_DETAILS = "details";
   private SendBirdPollDetails details;

--- a/src/main/java/org/openapitools/client/model/SendBirdPollDetails.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdPollDetails.java
@@ -48,7 +48,7 @@ import org.sendbird.client.JSON;
   SendBirdPollDetails.JSON_PROPERTY_VOTER_COUNT
 })
 @JsonTypeName("SendBird.PollDetails")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdPollDetails {
   public static final String JSON_PROPERTY_ALLOW_MULTIPLE_VOTES = "allow_multiple_votes";
   private Boolean allowMultipleVotes;

--- a/src/main/java/org/openapitools/client/model/SendBirdPollOption.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdPollOption.java
@@ -46,7 +46,7 @@ import org.sendbird.client.JSON;
   SendBirdPollOption.JSON_PROPERTY_VOTE_COUNT
 })
 @JsonTypeName("SendBird.PollOption")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdPollOption {
   public static final String JSON_PROPERTY_CREATED_AT = "created_at";
   private BigDecimal createdAt;

--- a/src/main/java/org/openapitools/client/model/SendBirdPollUpdatedVoteCount.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdPollUpdatedVoteCount.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SendBirdPollUpdatedVoteCount.JSON_PROPERTY_VOTE_COUNT
 })
 @JsonTypeName("SendBird.PollUpdatedVoteCount")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdPollUpdatedVoteCount {
   public static final String JSON_PROPERTY_OPTION_ID = "option_id";
   private BigDecimal optionId;

--- a/src/main/java/org/openapitools/client/model/SendBirdReaction.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdReaction.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   SendBirdReaction.JSON_PROPERTY_USER_IDS
 })
 @JsonTypeName("SendBird.Reaction")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdReaction {
   public static final String JSON_PROPERTY_KEY = "key";
   private String key;

--- a/src/main/java/org/openapitools/client/model/SendBirdRestrictionInfo.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdRestrictionInfo.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdRestrictionInfo.JSON_PROPERTY_RESTRICTION_TYPE
 })
 @JsonTypeName("SendBird.RestrictionInfo")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdRestrictionInfo {
   public static final String JSON_PROPERTY_DESCRIPTION = "description";
   private String description;

--- a/src/main/java/org/openapitools/client/model/SendBirdScheduledMessage.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdScheduledMessage.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   SendBirdScheduledMessage.JSON_PROPERTY_MESSAGE
 })
 @JsonTypeName("SendBird.ScheduledMessage")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdScheduledMessage {
   public static final String JSON_PROPERTY_SCHEDULED_MESSAGE_ID = "scheduled_message_id";
   private BigDecimal scheduledMessageId;

--- a/src/main/java/org/openapitools/client/model/SendBirdSender.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdSender.java
@@ -49,7 +49,7 @@ import org.sendbird.client.JSON;
   SendBirdSender.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("SendBird.Sender")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdSender {
   public static final String JSON_PROPERTY_CONNECTION_STATUS = "connection_status";
   private String connectionStatus;

--- a/src/main/java/org/openapitools/client/model/SendBirdThreadInfo.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdThreadInfo.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   SendBirdThreadInfo.JSON_PROPERTY_UPDATED_AT
 })
 @JsonTypeName("SendBird.ThreadInfo")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdThreadInfo {
   public static final String JSON_PROPERTY_LAST_REPLIED_AT = "last_replied_at";
   private BigDecimal lastRepliedAt;

--- a/src/main/java/org/openapitools/client/model/SendBirdThumbnailSBObject.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdThumbnailSBObject.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   SendBirdThumbnailSBObject.JSON_PROPERTY_WIDTH
 })
 @JsonTypeName("SendBird.ThumbnailSBObject")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdThumbnailSBObject {
   public static final String JSON_PROPERTY_HEIGHT = "height";
   private BigDecimal height;

--- a/src/main/java/org/openapitools/client/model/SendBirdThumbnailSize.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdThumbnailSize.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SendBirdThumbnailSize.JSON_PROPERTY_MAX_WIDTH
 })
 @JsonTypeName("SendBird.ThumbnailSize")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdThumbnailSize {
   public static final String JSON_PROPERTY_MAX_HEIGHT = "max_height";
   private BigDecimal maxHeight;

--- a/src/main/java/org/openapitools/client/model/SendBirdUser.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdUser.java
@@ -61,7 +61,7 @@ import org.sendbird.client.JSON;
   SendBirdUser.JSON_PROPERTY_START_AT
 })
 @JsonTypeName("SendBird.User")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdUser {
   public static final String JSON_PROPERTY_REQUIRE_AUTH_FOR_PROFILE_IMAGE = "require_auth_for_profile_image";
   private Boolean requireAuthForProfileImage;

--- a/src/main/java/org/openapitools/client/model/SendBirdUserMessageParams.java
+++ b/src/main/java/org/openapitools/client/model/SendBirdUserMessageParams.java
@@ -55,7 +55,7 @@ import org.sendbird.client.JSON;
   SendBirdUserMessageParams.JSON_PROPERTY_TRANSLATION_TARGET_LANGUAGES
 })
 @JsonTypeName("SendBird.UserMessageParams")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBirdUserMessageParams {
   public static final String JSON_PROPERTY_APPLE_CRITICAL_ALERT_OPTIONS = "apple_critical_alert_options";
   private SendBirdAppleCriticalAlertOptions appleCriticalAlertOptions;

--- a/src/main/java/org/openapitools/client/model/SendBotSMessageData.java
+++ b/src/main/java/org/openapitools/client/model/SendBotSMessageData.java
@@ -48,7 +48,7 @@ import org.sendbird.client.JSON;
   SendBotSMessageData.JSON_PROPERTY_TARGET_MESSAGE_ID
 })
 @JsonTypeName("sendBot_sMessageData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBotSMessageData {
   public static final String JSON_PROPERTY_MESSAGE = "message";
   private String message;

--- a/src/main/java/org/openapitools/client/model/SendBotSMessageDataExtendedMessagePayload.java
+++ b/src/main/java/org/openapitools/client/model/SendBotSMessageDataExtendedMessagePayload.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SendBotSMessageDataExtendedMessagePayload.JSON_PROPERTY_CUSTOM_VIEW
 })
 @JsonTypeName("sendBot_sMessageData_extended_message_payload")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendBotSMessageDataExtendedMessagePayload {
   public static final String JSON_PROPERTY_SUGGESTED_REPLIES = "suggested_replies";
   private List<String> suggestedReplies = null;

--- a/src/main/java/org/openapitools/client/model/SendMessageData.java
+++ b/src/main/java/org/openapitools/client/model/SendMessageData.java
@@ -63,7 +63,7 @@ import org.sendbird.client.JSON;
   SendMessageData.JSON_PROPERTY_THUMBNAIL3
 })
 @JsonTypeName("sendMessageData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SendMessageData {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterData.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterData.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterData.JSON_PROPERTY_IMAGE_MODERATION
 })
 @JsonTypeName("setDomainFilterData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SetDomainFilterData {
   public static final String JSON_PROPERTY_DOMAIN_FILTER = "domain_filter";
   private SetDomainFilterDataDomainFilter domainFilter;

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataDomainFilter.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataDomainFilter.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataDomainFilter.JSON_PROPERTY_SHOULD_CHECK_GLOBAL
 })
 @JsonTypeName("setDomainFilterData_domain_filter")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SetDomainFilterDataDomainFilter {
   public static final String JSON_PROPERTY_DOMAINS = "domains";
   private List<String> domains = null;

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataImageModeration.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataImageModeration.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataImageModeration.JSON_PROPERTY_CHECK_URLS
 })
 @JsonTypeName("setDomainFilterData_image_moderation")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SetDomainFilterDataImageModeration {
   public static final String JSON_PROPERTY_TYPE = "type";
   private Integer type;

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataImageModerationLimits.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataImageModerationLimits.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataImageModerationLimits.JSON_PROPERTY_RACY
 })
 @JsonTypeName("setDomainFilterData_image_moderation_limits")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SetDomainFilterDataImageModerationLimits {
   public static final String JSON_PROPERTY_ADULT = "adult";
   private Integer adult;

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityFilter.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityFilter.java
@@ -41,7 +41,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataProfanityFilter.JSON_PROPERTY_SHOULD_CHECK_GLOBAL
 })
 @JsonTypeName("setDomainFilterData_profanity_filter")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SetDomainFilterDataProfanityFilter {
   public static final String JSON_PROPERTY_KEYWORDS = "keywords";
   private List<String> keywords = null;

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityFilterRegexFiltersInner.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityFilterRegexFiltersInner.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataProfanityFilterRegexFiltersInner.JSON_PROPERTY_REGEX
 })
 @JsonTypeName("setDomainFilterData_profanity_filter_regex_filters_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SetDomainFilterDataProfanityFilterRegexFiltersInner {
   public static final String JSON_PROPERTY_REGEX = "regex";
   private String regex;

--- a/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityTriggeredModeration.java
+++ b/src/main/java/org/openapitools/client/model/SetDomainFilterDataProfanityTriggeredModeration.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   SetDomainFilterDataProfanityTriggeredModeration.JSON_PROPERTY_ACTION
 })
 @JsonTypeName("setDomainFilterData_profanity_triggered_moderation")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class SetDomainFilterDataProfanityTriggeredModeration {
   public static final String JSON_PROPERTY_COUNT = "count";
   private Integer count;

--- a/src/main/java/org/openapitools/client/model/TranslateMessageIntoOtherLanguagesData.java
+++ b/src/main/java/org/openapitools/client/model/TranslateMessageIntoOtherLanguagesData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   TranslateMessageIntoOtherLanguagesData.JSON_PROPERTY_TARGET_LANGS
 })
 @JsonTypeName("translateMessageIntoOtherLanguagesData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class TranslateMessageIntoOtherLanguagesData {
   public static final String JSON_PROPERTY_TARGET_LANGS = "target_langs";
   private List<String> targetLangs = null;

--- a/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdData.java
@@ -51,7 +51,7 @@ import org.sendbird.client.JSON;
   UpdateAnnouncementByIdData.JSON_PROPERTY_RESUME_AT
 })
 @JsonTypeName("updateAnnouncementByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateAnnouncementByIdData {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;

--- a/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   UpdateAnnouncementByIdResponse.JSON_PROPERTY_MESSAGE
 })
 @JsonTypeName("updateAnnouncementByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateAnnouncementByIdResponse {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;

--- a/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdResponseMessage.java
+++ b/src/main/java/org/openapitools/client/model/UpdateAnnouncementByIdResponseMessage.java
@@ -50,7 +50,7 @@ import org.sendbird.client.JSON;
   UpdateAnnouncementByIdResponseMessage.JSON_PROPERTY_OPEN_RATE
 })
 @JsonTypeName("updateAnnouncementByIdResponse_message")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateAnnouncementByIdResponseMessage {
   public static final String JSON_PROPERTY_TYPE = "type";
   private String type;

--- a/src/main/java/org/openapitools/client/model/UpdateApnsPushConfigurationByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateApnsPushConfigurationByIdData.java
@@ -44,7 +44,7 @@ import org.sendbird.client.JSON;
   UpdateApnsPushConfigurationByIdData.JSON_PROPERTY_APNS_TYPE
 })
 @JsonTypeName("updateApnsPushConfigurationByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateApnsPushConfigurationByIdData {
   public static final String JSON_PROPERTY_PROVIDER_ID = "provider_id";
   private String providerId;

--- a/src/main/java/org/openapitools/client/model/UpdateApnsPushConfigurationByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateApnsPushConfigurationByIdResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateApnsPushConfigurationByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("updateApnsPushConfigurationByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateApnsPushConfigurationByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private String pushConfigurations;

--- a/src/main/java/org/openapitools/client/model/UpdateBotByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateBotByIdData.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   UpdateBotByIdData.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("updateBotByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateBotByIdData {
   public static final String JSON_PROPERTY_BOT_USERID = "bot_userid";
   private String botUserid;

--- a/src/main/java/org/openapitools/client/model/UpdateBotByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateBotByIdResponse.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   UpdateBotByIdResponse.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("updateBotByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateBotByIdResponse {
   public static final String JSON_PROPERTY_BOT = "bot";
   private CreateBotResponseBot bot;

--- a/src/main/java/org/openapitools/client/model/UpdateChannelInvitationPreferenceData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateChannelInvitationPreferenceData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateChannelInvitationPreferenceData.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("updateChannelInvitationPreferenceData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateChannelInvitationPreferenceData {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;

--- a/src/main/java/org/openapitools/client/model/UpdateChannelInvitationPreferenceResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateChannelInvitationPreferenceResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateChannelInvitationPreferenceResponse.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("updateChannelInvitationPreferenceResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateChannelInvitationPreferenceResponse {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;

--- a/src/main/java/org/openapitools/client/model/UpdateChannelMetacounterData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateChannelMetacounterData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   UpdateChannelMetacounterData.JSON_PROPERTY_UPSERT
 })
 @JsonTypeName("updateChannelMetacounterData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateChannelMetacounterData {
   public static final String JSON_PROPERTY_METACOUNTER = "metacounter";
   private String metacounter;

--- a/src/main/java/org/openapitools/client/model/UpdateChannelMetadataData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateChannelMetadataData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   UpdateChannelMetadataData.JSON_PROPERTY_UPSERT
 })
 @JsonTypeName("updateChannelMetadataData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateChannelMetadataData {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   private Object metadata;

--- a/src/main/java/org/openapitools/client/model/UpdateCountPreferenceOfChannelByUrlData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateCountPreferenceOfChannelByUrlData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateCountPreferenceOfChannelByUrlData.JSON_PROPERTY_COUNT_PREFERENCE
 })
 @JsonTypeName("updateCountPreferenceOfChannelByUrlData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateCountPreferenceOfChannelByUrlData {
   public static final String JSON_PROPERTY_COUNT_PREFERENCE = "count_preference";
   private String countPreference;

--- a/src/main/java/org/openapitools/client/model/UpdateCountPreferenceOfChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateCountPreferenceOfChannelByUrlResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateCountPreferenceOfChannelByUrlResponse.JSON_PROPERTY_COUNT_PREFERENCE
 })
 @JsonTypeName("updateCountPreferenceOfChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateCountPreferenceOfChannelByUrlResponse {
   public static final String JSON_PROPERTY_COUNT_PREFERENCE = "count_preference";
   private String countPreference;

--- a/src/main/java/org/openapitools/client/model/UpdateDefaultChannelInvitationPreferenceData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateDefaultChannelInvitationPreferenceData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateDefaultChannelInvitationPreferenceData.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("updateDefaultChannelInvitationPreferenceData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateDefaultChannelInvitationPreferenceData {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;

--- a/src/main/java/org/openapitools/client/model/UpdateDefaultChannelInvitationPreferenceResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateDefaultChannelInvitationPreferenceResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateDefaultChannelInvitationPreferenceResponse.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("updateDefaultChannelInvitationPreferenceResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateDefaultChannelInvitationPreferenceResponse {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;

--- a/src/main/java/org/openapitools/client/model/UpdateEmojiCategoryUrlByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateEmojiCategoryUrlByIdData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   UpdateEmojiCategoryUrlByIdData.JSON_PROPERTY_URL
 })
 @JsonTypeName("updateEmojiCategoryUrlByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateEmojiCategoryUrlByIdData {
   public static final String JSON_PROPERTY_EMOJI_CATEGORY_ID = "emoji_category_id";
   private Integer emojiCategoryId;

--- a/src/main/java/org/openapitools/client/model/UpdateEmojiUrlByKeyData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateEmojiUrlByKeyData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   UpdateEmojiUrlByKeyData.JSON_PROPERTY_URL
 })
 @JsonTypeName("updateEmojiUrlByKeyData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateEmojiUrlByKeyData {
   public static final String JSON_PROPERTY_EMOJI_KEY = "emoji_key";
   private String emojiKey;

--- a/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageData.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   UpdateExtraDataInMessageData.JSON_PROPERTY_UPSERT
 })
 @JsonTypeName("updateExtraDataInMessageData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateExtraDataInMessageData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;

--- a/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   UpdateExtraDataInMessageResponse.JSON_PROPERTY_SORTED_METAARRAY
 })
 @JsonTypeName("updateExtraDataInMessageResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateExtraDataInMessageResponse {
   public static final String JSON_PROPERTY_SORTED_METAARRAY = "sorted_metaarray";
   private List<UpdateExtraDataInMessageResponseSortedMetaarrayInner> sortedMetaarray = null;

--- a/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageResponseSortedMetaarrayInner.java
+++ b/src/main/java/org/openapitools/client/model/UpdateExtraDataInMessageResponseSortedMetaarrayInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   UpdateExtraDataInMessageResponseSortedMetaarrayInner.JSON_PROPERTY_KEY
 })
 @JsonTypeName("updateExtraDataInMessageResponse_sorted_metaarray_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateExtraDataInMessageResponseSortedMetaarrayInner {
   public static final String JSON_PROPERTY_VALUE = "value";
   private List<String> value = null;

--- a/src/main/java/org/openapitools/client/model/UpdateFcmPushConfigurationByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateFcmPushConfigurationByIdData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   UpdateFcmPushConfigurationByIdData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("updateFcmPushConfigurationByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateFcmPushConfigurationByIdData {
   public static final String JSON_PROPERTY_PROVIDER_ID = "provider_id";
   private String providerId;

--- a/src/main/java/org/openapitools/client/model/UpdateFcmPushConfigurationByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateFcmPushConfigurationByIdResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateFcmPushConfigurationByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("updateFcmPushConfigurationByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateFcmPushConfigurationByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private String pushConfigurations;

--- a/src/main/java/org/openapitools/client/model/UpdateHmsPushConfigurationByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateHmsPushConfigurationByIdData.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   UpdateHmsPushConfigurationByIdData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("updateHmsPushConfigurationByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateHmsPushConfigurationByIdData {
   public static final String JSON_PROPERTY_PROVIDER_ID = "provider_id";
   private String providerId;

--- a/src/main/java/org/openapitools/client/model/UpdateHmsPushConfigurationByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateHmsPushConfigurationByIdResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UpdateHmsPushConfigurationByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("updateHmsPushConfigurationByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateHmsPushConfigurationByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private String pushConfigurations;

--- a/src/main/java/org/openapitools/client/model/UpdateMessageByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateMessageByIdData.java
@@ -45,7 +45,7 @@ import org.sendbird.client.JSON;
   UpdateMessageByIdData.JSON_PROPERTY_MENTIONED_USER_IDS
 })
 @JsonTypeName("updateMessageByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateMessageByIdData {
   public static final String JSON_PROPERTY_CHANNEL_TYPE = "channel_type";
   private String channelType;

--- a/src/main/java/org/openapitools/client/model/UpdatePushNotificationContentTemplateData.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushNotificationContentTemplateData.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   UpdatePushNotificationContentTemplateData.JSON_PROPERTY_TEMPLATE_A_D_M_N
 })
 @JsonTypeName("updatePushNotificationContentTemplateData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdatePushNotificationContentTemplateData {
   public static final String JSON_PROPERTY_TEMPLATE_NAME = "template_name";
   private String templateName;

--- a/src/main/java/org/openapitools/client/model/UpdatePushNotificationContentTemplateResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushNotificationContentTemplateResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   UpdatePushNotificationContentTemplateResponse.JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES
 })
 @JsonTypeName("updatePushNotificationContentTemplateResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdatePushNotificationContentTemplateResponse {
   public static final String JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES = "push_message_templates";
   private List<ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner> pushMessageTemplates = null;

--- a/src/main/java/org/openapitools/client/model/UpdatePushPreferencesData.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushPreferencesData.java
@@ -49,7 +49,7 @@ import org.sendbird.client.JSON;
   UpdatePushPreferencesData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("updatePushPreferencesData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdatePushPreferencesData {
   public static final String JSON_PROPERTY_PUSH_TRIGGER_OPTION = "push_trigger_option";
   private String pushTriggerOption;

--- a/src/main/java/org/openapitools/client/model/UpdatePushPreferencesForChannelByUrlData.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushPreferencesForChannelByUrlData.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   UpdatePushPreferencesForChannelByUrlData.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("updatePushPreferencesForChannelByUrlData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdatePushPreferencesForChannelByUrlData {
   public static final String JSON_PROPERTY_PUSH_TRIGGER_OPTION = "push_trigger_option";
   private String pushTriggerOption;

--- a/src/main/java/org/openapitools/client/model/UpdatePushPreferencesForChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushPreferencesForChannelByUrlResponse.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   UpdatePushPreferencesForChannelByUrlResponse.JSON_PROPERTY_ENABLE
 })
 @JsonTypeName("updatePushPreferencesForChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdatePushPreferencesForChannelByUrlResponse {
   public static final String JSON_PROPERTY_PUSH_TRIGGER_OPTION = "push_trigger_option";
   private String pushTriggerOption;

--- a/src/main/java/org/openapitools/client/model/UpdatePushPreferencesResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdatePushPreferencesResponse.java
@@ -51,7 +51,7 @@ import org.sendbird.client.JSON;
   UpdatePushPreferencesResponse.JSON_PROPERTY_PUSH_SOUND
 })
 @JsonTypeName("updatePushPreferencesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdatePushPreferencesResponse {
   public static final String JSON_PROPERTY_BLOCK_PUSH_FROM_BOTS = "block_push_from_bots";
   private Boolean blockPushFromBots;

--- a/src/main/java/org/openapitools/client/model/UpdateUserByIdData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateUserByIdData.java
@@ -49,7 +49,7 @@ import org.sendbird.client.JSON;
   UpdateUserByIdData.JSON_PROPERTY_LEAVE_ALL_WHEN_DEACTIVATED
 })
 @JsonTypeName("updateUserByIdData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateUserByIdData {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;
@@ -125,10 +125,10 @@ public class UpdateUserByIdData {
    * Specifies the user&#39;s nickname. The length is limited to 80 characters.
    * @return nickname
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "Specifies the user's nickname. The length is limited to 80 characters.")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Specifies the user's nickname. The length is limited to 80 characters.")
   @JsonProperty(JSON_PROPERTY_NICKNAME)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public String getNickname() {
     return nickname;
@@ -136,7 +136,7 @@ public class UpdateUserByIdData {
 
 
   @JsonProperty(JSON_PROPERTY_NICKNAME)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNickname(String nickname) {
     this.nickname = nickname;
   }
@@ -151,10 +151,10 @@ public class UpdateUserByIdData {
    * Specifies the URL of the user&#39;s profile image. The length is limited to 2,048 characters.&lt;br /&gt;&lt;br /&gt; The [domain filter](/docs/chat/v3/platform-api/guides/filter-and-moderation#2-domain-filter) filters out the request if the value of this property matches the filter&#39;s domain set.
    * @return profileUrl
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "Specifies the URL of the user's profile image. The length is limited to 2,048 characters.<br /><br /> The [domain filter](/docs/chat/v3/platform-api/guides/filter-and-moderation#2-domain-filter) filters out the request if the value of this property matches the filter's domain set.")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Specifies the URL of the user's profile image. The length is limited to 2,048 characters.<br /><br /> The [domain filter](/docs/chat/v3/platform-api/guides/filter-and-moderation#2-domain-filter) filters out the request if the value of this property matches the filter's domain set.")
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public String getProfileUrl() {
     return profileUrl;
@@ -162,7 +162,7 @@ public class UpdateUserByIdData {
 
 
   @JsonProperty(JSON_PROPERTY_PROFILE_URL)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProfileUrl(String profileUrl) {
     this.profileUrl = profileUrl;
   }

--- a/src/main/java/org/openapitools/client/model/UpdateUserMetadataData.java
+++ b/src/main/java/org/openapitools/client/model/UpdateUserMetadataData.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   UpdateUserMetadataData.JSON_PROPERTY_UPSERT
 })
 @JsonTypeName("updateUserMetadataData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateUserMetadataData {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   private Object metadata;

--- a/src/main/java/org/openapitools/client/model/UpdateUserMetadataResponse.java
+++ b/src/main/java/org/openapitools/client/model/UpdateUserMetadataResponse.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   UpdateUserMetadataResponse.JSON_PROPERTY_UPSERT
 })
 @JsonTypeName("updateUserMetadataResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UpdateUserMetadataResponse {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   private Map<String, String> metadata = null;

--- a/src/main/java/org/openapitools/client/model/UseDefaultEmojisData.java
+++ b/src/main/java/org/openapitools/client/model/UseDefaultEmojisData.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UseDefaultEmojisData.JSON_PROPERTY_USE_DEFAULT_EMOJI
 })
 @JsonTypeName("useDefaultEmojisData")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UseDefaultEmojisData {
   public static final String JSON_PROPERTY_USE_DEFAULT_EMOJI = "use_default_emoji";
   private Boolean useDefaultEmoji;

--- a/src/main/java/org/openapitools/client/model/UseDefaultEmojisResponse.java
+++ b/src/main/java/org/openapitools/client/model/UseDefaultEmojisResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   UseDefaultEmojisResponse.JSON_PROPERTY_USE_DEFAULT_EMOJI
 })
 @JsonTypeName("useDefaultEmojisResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UseDefaultEmojisResponse {
   public static final String JSON_PROPERTY_USE_DEFAULT_EMOJI = "use_default_emoji";
   private Boolean useDefaultEmoji;

--- a/src/main/java/org/openapitools/client/model/V3ApplicationsPushSettingsGet200Response.java
+++ b/src/main/java/org/openapitools/client/model/V3ApplicationsPushSettingsGet200Response.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   V3ApplicationsPushSettingsGet200Response.JSON_PROPERTY_PUSH_ENABLED
 })
 @JsonTypeName("_v3_applications_push_settings_get_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3ApplicationsPushSettingsGet200Response {
   public static final String JSON_PROPERTY_PUSH_ENABLED = "push_enabled";
   private Boolean pushEnabled;

--- a/src/main/java/org/openapitools/client/model/V3ApplicationsPushSettingsGetRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3ApplicationsPushSettingsGetRequest.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   V3ApplicationsPushSettingsGetRequest.JSON_PROPERTY_PUSH_ENABLED
 })
 @JsonTypeName("_v3_applications_push_settings_get_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3ApplicationsPushSettingsGetRequest {
   public static final String JSON_PROPERTY_PUSH_ENABLED = "push_enabled";
   private Boolean pushEnabled;

--- a/src/main/java/org/openapitools/client/model/V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteRequest.java
@@ -56,7 +56,7 @@ import org.sendbird.client.JSON;
   V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteRequest.JSON_PROPERTY_VOLUME
 })
 @JsonTypeName("_v3_group_channels__channel_url__scheduled_messages__scheduled_message_id__delete_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3GroupChannelsChannelUrlScheduledMessagesScheduledMessageIdDeleteRequest {
   public static final String JSON_PROPERTY_MESSAGE_TYPE = "message_type";
   private String messageType;

--- a/src/main/java/org/openapitools/client/model/V3PollsGetRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsGetRequest.java
@@ -43,7 +43,7 @@ import org.sendbird.client.JSON;
   V3PollsGetRequest.JSON_PROPERTY_DATA
 })
 @JsonTypeName("_v3_polls_get_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3PollsGetRequest {
   public static final String JSON_PROPERTY_TITLE = "title";
   private String title;

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdDeleteRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdDeleteRequest.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdDeleteRequest.JSON_PROPERTY_SHOW_PARTIAL_VOTER_LIST
 })
 @JsonTypeName("_v3_polls__poll_id__delete_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3PollsPollIdDeleteRequest {
   public static final String JSON_PROPERTY_CHANNEL_URL = "channel_url";
   private String channelUrl;

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdDeleteRequest1.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdDeleteRequest1.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdDeleteRequest1.JSON_PROPERTY_DATA
 })
 @JsonTypeName("_v3_polls__poll_id__delete_request_1")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3PollsPollIdDeleteRequest1 {
   public static final String JSON_PROPERTY_TITLE = "title";
   private String title;

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdDeleteRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdDeleteRequest.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdOptionsOptionIdDeleteRequest.JSON_PROPERTY_CREATED_BY
 })
 @JsonTypeName("_v3_polls__poll_id__options__option_id__delete_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3PollsPollIdOptionsOptionIdDeleteRequest {
   public static final String JSON_PROPERTY_TEXT = "text";
   private String text;

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGet200Response.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGet200Response.java
@@ -40,7 +40,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdOptionsOptionIdVotersGet200Response.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("_v3_polls__poll_id__options__option_id__voters_get_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3PollsPollIdOptionsOptionIdVotersGet200Response {
   public static final String JSON_PROPERTY_VOTE_COUNT = "vote_count";
   private Integer voteCount;

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("_v3_polls__poll_id__options__option_id__voters_get_200_response_voters_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3PollsPollIdOptionsOptionIdVotersGet200ResponseVotersInner {
   public static final String JSON_PROPERTY_NICKNAME = "nickname";
   private String nickname;

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGetRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdOptionsOptionIdVotersGetRequest.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdOptionsOptionIdVotersGetRequest.JSON_PROPERTY_LIMIT
 })
 @JsonTypeName("_v3_polls__poll_id__options__option_id__voters_get_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3PollsPollIdOptionsOptionIdVotersGetRequest {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;

--- a/src/main/java/org/openapitools/client/model/V3PollsPollIdVotePutRequest.java
+++ b/src/main/java/org/openapitools/client/model/V3PollsPollIdVotePutRequest.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   V3PollsPollIdVotePutRequest.JSON_PROPERTY_OPTION_IDS
 })
 @JsonTypeName("_v3_polls__poll_id__vote_put_request")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3PollsPollIdVotePutRequest {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/openapitools/client/model/V3ScheduledMessagesCountGet200Response.java
+++ b/src/main/java/org/openapitools/client/model/V3ScheduledMessagesCountGet200Response.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   V3ScheduledMessagesCountGet200Response.JSON_PROPERTY_COUNT
 })
 @JsonTypeName("_v3_scheduled_messages_count_get_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3ScheduledMessagesCountGet200Response {
   public static final String JSON_PROPERTY_COUNT = "count";
   private BigDecimal count;

--- a/src/main/java/org/openapitools/client/model/V3ScheduledMessagesGet200Response.java
+++ b/src/main/java/org/openapitools/client/model/V3ScheduledMessagesGet200Response.java
@@ -39,7 +39,7 @@ import org.sendbird.client.JSON;
   V3ScheduledMessagesGet200Response.JSON_PROPERTY_NEXT
 })
 @JsonTypeName("_v3_scheduled_messages_get_200_response")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class V3ScheduledMessagesGet200Response {
   public static final String JSON_PROPERTY_SCHEDULED_MESSAGES = "scheduled_messages";
   private List<SendBirdScheduledMessage> scheduledMessages = null;

--- a/src/main/java/org/openapitools/client/model/ViewAnnouncementByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewAnnouncementByIdResponse.java
@@ -59,7 +59,7 @@ import org.sendbird.client.JSON;
   ViewAnnouncementByIdResponse.JSON_PROPERTY_TARGET_CUSTOM_TYPE
 })
 @JsonTypeName("viewAnnouncementByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewAnnouncementByIdResponse {
   public static final String JSON_PROPERTY_UNIQUE_ID = "unique_id";
   private String uniqueId;

--- a/src/main/java/org/openapitools/client/model/ViewBotByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewBotByIdResponse.java
@@ -42,7 +42,7 @@ import org.sendbird.client.JSON;
   ViewBotByIdResponse.JSON_PROPERTY_CHANNEL_INVITATION_PREFERENCE
 })
 @JsonTypeName("viewBotByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewBotByIdResponse {
   public static final String JSON_PROPERTY_BOT = "bot";
   private CreateBotResponseBot bot;

--- a/src/main/java/org/openapitools/client/model/ViewChannelInvitationPreferenceResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewChannelInvitationPreferenceResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ViewChannelInvitationPreferenceResponse.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("viewChannelInvitationPreferenceResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewChannelInvitationPreferenceResponse {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;

--- a/src/main/java/org/openapitools/client/model/ViewCountPreferenceOfChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewCountPreferenceOfChannelByUrlResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ViewCountPreferenceOfChannelByUrlResponse.JSON_PROPERTY_COUNT_PREFERENCE
 })
 @JsonTypeName("viewCountPreferenceOfChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewCountPreferenceOfChannelByUrlResponse {
   public static final String JSON_PROPERTY_COUNT_PREFERENCE = "count_preference";
   private String countPreference;

--- a/src/main/java/org/openapitools/client/model/ViewDataExportByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewDataExportByIdResponse.java
@@ -52,7 +52,7 @@ import org.sendbird.client.JSON;
   ViewDataExportByIdResponse.JSON_PROPERTY_USER_IDS
 })
 @JsonTypeName("viewDataExportByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewDataExportByIdResponse {
   public static final String JSON_PROPERTY_REQUEST_ID = "request_id";
   private String requestId;

--- a/src/main/java/org/openapitools/client/model/ViewDefaultChannelInvitationPreferenceResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewDefaultChannelInvitationPreferenceResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ViewDefaultChannelInvitationPreferenceResponse.JSON_PROPERTY_AUTO_ACCEPT
 })
 @JsonTypeName("viewDefaultChannelInvitationPreferenceResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewDefaultChannelInvitationPreferenceResponse {
   public static final String JSON_PROPERTY_AUTO_ACCEPT = "auto_accept";
   private Boolean autoAccept;

--- a/src/main/java/org/openapitools/client/model/ViewGdprRequestByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewGdprRequestByIdResponse.java
@@ -46,7 +46,7 @@ import org.sendbird.client.JSON;
   ViewGdprRequestByIdResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("viewGdprRequestByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewGdprRequestByIdResponse {
   public static final String JSON_PROPERTY_REQUEST_ID = "request_id";
   private String requestId;

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfChannelsByJoinStatusResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfChannelsByJoinStatusResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfChannelsByJoinStatusResponse.JSON_PROPERTY_GROUP_CHANNEL_COUNT
 })
 @JsonTypeName("viewNumberOfChannelsByJoinStatusResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewNumberOfChannelsByJoinStatusResponse {
   public static final String JSON_PROPERTY_GROUP_CHANNEL_COUNT = "group_channel_count";
   private BigDecimal groupChannelCount;

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfChannelsWithUnreadMessagesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfChannelsWithUnreadMessagesResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfChannelsWithUnreadMessagesResponse.JSON_PROPERTY_UNREAD_COUNT
 })
 @JsonTypeName("viewNumberOfChannelsWithUnreadMessagesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewNumberOfChannelsWithUnreadMessagesResponse {
   public static final String JSON_PROPERTY_UNREAD_COUNT = "unread_count";
   private BigDecimal unreadCount;

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfConcurrentConnectionsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfConcurrentConnectionsResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfConcurrentConnectionsResponse.JSON_PROPERTY_CCU
 })
 @JsonTypeName("viewNumberOfConcurrentConnectionsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewNumberOfConcurrentConnectionsResponse {
   public static final String JSON_PROPERTY_CCU = "ccu";
   private BigDecimal ccu;

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfDailyActiveUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfDailyActiveUsersResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfDailyActiveUsersResponse.JSON_PROPERTY_DAU
 })
 @JsonTypeName("viewNumberOfDailyActiveUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewNumberOfDailyActiveUsersResponse {
   public static final String JSON_PROPERTY_DAU = "dau";
   private BigDecimal dau;

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfMonthlyActiveUsersResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfMonthlyActiveUsersResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfMonthlyActiveUsersResponse.JSON_PROPERTY_MAU
 })
 @JsonTypeName("viewNumberOfMonthlyActiveUsersResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewNumberOfMonthlyActiveUsersResponse {
   public static final String JSON_PROPERTY_MAU = "mau";
   private BigDecimal mau;

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfPeakConnectionsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfPeakConnectionsResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfPeakConnectionsResponse.JSON_PROPERTY_PEAK_CONNECTIONS
 })
 @JsonTypeName("viewNumberOfPeakConnectionsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewNumberOfPeakConnectionsResponse {
   public static final String JSON_PROPERTY_PEAK_CONNECTIONS = "peak_connections";
   private List<ViewNumberOfPeakConnectionsResponsePeakConnectionsInner> peakConnections = null;

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfPeakConnectionsResponsePeakConnectionsInner.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfPeakConnectionsResponsePeakConnectionsInner.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfPeakConnectionsResponsePeakConnectionsInner.JSON_PROPERTY_PEAK_CONNECTIONS
 })
 @JsonTypeName("viewNumberOfPeakConnectionsResponse_peak_connections_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewNumberOfPeakConnectionsResponsePeakConnectionsInner {
   public static final String JSON_PROPERTY_DATE = "date";
   private String date;

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfUnreadItemsResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfUnreadItemsResponse.java
@@ -44,7 +44,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfUnreadItemsResponse.JSON_PROPERTY_NON_SUPER_GROUP_CHANNEL_INVITATION_COUNT
 })
 @JsonTypeName("viewNumberOfUnreadItemsResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewNumberOfUnreadItemsResponse {
   public static final String JSON_PROPERTY_NON_SUPER_GROUP_CHANNEL_UNREAD_MESSAGE_COUNT = "non_super_group_channel_unread_message_count";
   private BigDecimal nonSuperGroupChannelUnreadMessageCount;

--- a/src/main/java/org/openapitools/client/model/ViewNumberOfUnreadMessagesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewNumberOfUnreadMessagesResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewNumberOfUnreadMessagesResponse.JSON_PROPERTY_UNREAD_COUNT
 })
 @JsonTypeName("viewNumberOfUnreadMessagesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewNumberOfUnreadMessagesResponse {
   public static final String JSON_PROPERTY_UNREAD_COUNT = "unread_count";
   private BigDecimal unreadCount;

--- a/src/main/java/org/openapitools/client/model/ViewPushConfigurationByIdResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewPushConfigurationByIdResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ViewPushConfigurationByIdResponse.JSON_PROPERTY_PUSH_CONFIGURATIONS
 })
 @JsonTypeName("viewPushConfigurationByIdResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewPushConfigurationByIdResponse {
   public static final String JSON_PROPERTY_PUSH_CONFIGURATIONS = "push_configurations";
   private List<ListPushConfigurationsResponsePushConfigurationsInner> pushConfigurations = null;

--- a/src/main/java/org/openapitools/client/model/ViewPushNotificationContentTemplateResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewPushNotificationContentTemplateResponse.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ViewPushNotificationContentTemplateResponse.JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES
 })
 @JsonTypeName("viewPushNotificationContentTemplateResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewPushNotificationContentTemplateResponse {
   public static final String JSON_PROPERTY_PUSH_MESSAGE_TEMPLATES = "push_message_templates";
   private List<ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner> pushMessageTemplates = null;

--- a/src/main/java/org/openapitools/client/model/ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner.java
+++ b/src/main/java/org/openapitools/client/model/ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner.java
@@ -38,7 +38,7 @@ import org.sendbird.client.JSON;
   ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner.JSON_PROPERTY_PUSH_MESSAGE_PREVIEW
 })
 @JsonTypeName("viewPushNotificationContentTemplateResponse_push_message_templates_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewPushNotificationContentTemplateResponsePushMessageTemplatesInner {
   public static final String JSON_PROPERTY_TEMPLATE_NAME = "template_name";
   private String templateName;

--- a/src/main/java/org/openapitools/client/model/ViewPushPreferencesForChannelByUrlResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewPushPreferencesForChannelByUrlResponse.java
@@ -47,7 +47,7 @@ import org.sendbird.client.JSON;
   ViewPushPreferencesForChannelByUrlResponse.JSON_PROPERTY_ENABLE
 })
 @JsonTypeName("viewPushPreferencesForChannelByUrlResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewPushPreferencesForChannelByUrlResponse {
   public static final String JSON_PROPERTY_PUSH_TRIGGER_OPTION = "push_trigger_option";
   private String pushTriggerOption;

--- a/src/main/java/org/openapitools/client/model/ViewPushPreferencesResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewPushPreferencesResponse.java
@@ -51,7 +51,7 @@ import org.sendbird.client.JSON;
   ViewPushPreferencesResponse.JSON_PROPERTY_PUSH_TRIGGER_OPTION
 })
 @JsonTypeName("viewPushPreferencesResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewPushPreferencesResponse {
   public static final String JSON_PROPERTY_SNOOZE_START_TS = "snooze_start_ts";
   private String snoozeStartTs;

--- a/src/main/java/org/openapitools/client/model/ViewSecondaryApiTokenByTokenResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewSecondaryApiTokenByTokenResponse.java
@@ -37,7 +37,7 @@ import org.sendbird.client.JSON;
   ViewSecondaryApiTokenByTokenResponse.JSON_PROPERTY_CREATED_AT
 })
 @JsonTypeName("viewSecondaryApiTokenByTokenResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewSecondaryApiTokenByTokenResponse {
   public static final String JSON_PROPERTY_TOKEN = "token";
   private String token;

--- a/src/main/java/org/openapitools/client/model/ViewTotalNumberOfMessagesInChannelResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewTotalNumberOfMessagesInChannelResponse.java
@@ -36,7 +36,7 @@ import org.sendbird.client.JSON;
   ViewTotalNumberOfMessagesInChannelResponse.JSON_PROPERTY_TOTAL
 })
 @JsonTypeName("viewTotalNumberOfMessagesInChannelResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewTotalNumberOfMessagesInChannelResponse {
   public static final String JSON_PROPERTY_TOTAL = "total";
   private BigDecimal total;

--- a/src/main/java/org/openapitools/client/model/ViewUserMetadataResponse.java
+++ b/src/main/java/org/openapitools/client/model/ViewUserMetadataResponse.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ViewUserMetadataResponse.JSON_PROPERTY_ANY_OF
 })
 @JsonTypeName("viewUserMetadataResponse")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewUserMetadataResponse {
   public static final String JSON_PROPERTY_ANY_OF = "anyOf";
   private String anyOf;

--- a/src/main/java/org/openapitools/client/model/ViewWhoOwnsRegistrationOrDeviceTokenByTokenResponseInner.java
+++ b/src/main/java/org/openapitools/client/model/ViewWhoOwnsRegistrationOrDeviceTokenByTokenResponseInner.java
@@ -35,7 +35,7 @@ import org.sendbird.client.JSON;
   ViewWhoOwnsRegistrationOrDeviceTokenByTokenResponseInner.JSON_PROPERTY_USER_ID
 })
 @JsonTypeName("viewWhoOwnsRegistrationOrDeviceTokenByTokenResponse_inner")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ViewWhoOwnsRegistrationOrDeviceTokenByTokenResponseInner {
   public static final String JSON_PROPERTY_USER_ID = "user_id";
   private String userId;

--- a/src/main/java/org/sendbird/client/ApiClient.java
+++ b/src/main/java/org/sendbird/client/ApiClient.java
@@ -66,7 +66,7 @@ import org.sendbird.client.auth.ApiKeyAuth;
 /**
  * <p>ApiClient class.</p>
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ApiClient extends JavaTimeFormatter {
   protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
@@ -127,7 +127,7 @@ public class ApiClient extends JavaTimeFormatter {
     this.dateFormat = new RFC3339DateFormat();
 
     // Set default User-Agent.
-    setUserAgent("OpenAPI-Generator/1.0.23/java");
+    setUserAgent("OpenAPI-Generator/1.0.25/java");
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();

--- a/src/main/java/org/sendbird/client/ApiException.java
+++ b/src/main/java/org/sendbird/client/ApiException.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * API Exception
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/src/main/java/org/sendbird/client/Configuration.java
+++ b/src/main/java/org/sendbird/client/Configuration.java
@@ -13,7 +13,7 @@
 
 package org.sendbird.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class Configuration {
     private static ApiClient defaultApiClient = new ApiClient();
 

--- a/src/main/java/org/sendbird/client/JSON.java
+++ b/src/main/java/org/sendbird/client/JSON.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.ext.ContextResolver;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class JSON implements ContextResolver<ObjectMapper> {
   private ObjectMapper mapper;
 

--- a/src/main/java/org/sendbird/client/JSON.java-e
+++ b/src/main/java/org/sendbird/client/JSON.java-e
@@ -15,7 +15,7 @@ import java.util.Set;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.ext.ContextResolver;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class JSON implements ContextResolver<ObjectMapper> {
   private ObjectMapper mapper;
 

--- a/src/main/java/org/sendbird/client/JavaTimeFormatter.java
+++ b/src/main/java/org/sendbird/client/JavaTimeFormatter.java
@@ -20,7 +20,7 @@ import java.time.format.DateTimeParseException;
  * Class that add parsing/formatting support for Java 8+ {@code OffsetDateTime} class.
  * It's generated for java clients when {@code AbstractJavaCodegen#dateLibrary} specified as {@code java8}.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class JavaTimeFormatter {
 
     private DateTimeFormatter offsetDateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;

--- a/src/main/java/org/sendbird/client/Pair.java
+++ b/src/main/java/org/sendbird/client/Pair.java
@@ -13,7 +13,7 @@
 
 package org.sendbird.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/org/sendbird/client/StringUtil.java
+++ b/src/main/java/org/sendbird/client/StringUtil.java
@@ -16,7 +16,7 @@ package org.sendbird.client;
 import java.util.Collection;
 import java.util.Iterator;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/org/sendbird/client/api/AnnouncementApi.java
+++ b/src/main/java/org/sendbird/client/api/AnnouncementApi.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class AnnouncementApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/ApplicationApi.java
+++ b/src/main/java/org/sendbird/client/api/ApplicationApi.java
@@ -54,7 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ApplicationApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/BotApi.java
+++ b/src/main/java/org/sendbird/client/api/BotApi.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class BotApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/DataExportApi.java
+++ b/src/main/java/org/sendbird/client/api/DataExportApi.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class DataExportApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/DeleteAPinApi.java
+++ b/src/main/java/org/sendbird/client/api/DeleteAPinApi.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class DeleteAPinApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/GroupChannelApi.java
+++ b/src/main/java/org/sendbird/client/api/GroupChannelApi.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class GroupChannelApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/MessageApi.java
+++ b/src/main/java/org/sendbird/client/api/MessageApi.java
@@ -46,7 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class MessageApi {
   private ApiClient apiClient;
 
@@ -1239,7 +1239,7 @@ private ApiResponse<Object> gcMarkAllMessagesAsReadWithHttpInfo(String channelUr
     return new APIgcMarkAllMessagesAsReadRequest(channelUrl);
   }
 
-private ApiResponse<GcViewNumberOfEachMembersUnreadMessagesResponse> gcViewNumberOfEachMembersUnreadMessagesWithHttpInfo(String channelUrl, String apiToken, String userIds) throws ApiException {
+private ApiResponse<GcViewNumberOfEachMembersUnreadMessagesResponse> gcViewNumberOfEachMembersUnreadMessagesWithHttpInfo(String channelUrl, String apiToken, List<String> userIds) throws ApiException {
     Object localVarPostBody = null;
     
     // verify the required parameter 'channelUrl' is set
@@ -1257,7 +1257,7 @@ private ApiResponse<GcViewNumberOfEachMembersUnreadMessagesResponse> gcViewNumbe
     Map<String, String> localVarCookieParams = new HashMap<String, String>();
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "user_ids", userIds));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "user_ids", userIds));
 
     if (apiToken != null)
       localVarHeaderParams.put("Api-Token", apiClient.parameterToString(apiToken));
@@ -1286,7 +1286,7 @@ private ApiResponse<GcViewNumberOfEachMembersUnreadMessagesResponse> gcViewNumbe
   public class APIgcViewNumberOfEachMembersUnreadMessagesRequest {
     private String channelUrl;
     private String apiToken;
-    private String userIds;
+    private List<String> userIds;
 
     private APIgcViewNumberOfEachMembersUnreadMessagesRequest(String channelUrl) {
       this.channelUrl = channelUrl;
@@ -1307,7 +1307,7 @@ private ApiResponse<GcViewNumberOfEachMembersUnreadMessagesResponse> gcViewNumbe
      * @param userIds  (optional)
      * @return APIgcViewNumberOfEachMembersUnreadMessagesRequest
      */
-    public APIgcViewNumberOfEachMembersUnreadMessagesRequest userIds(String userIds) {
+    public APIgcViewNumberOfEachMembersUnreadMessagesRequest userIds(List<String> userIds) {
       this.userIds = userIds;
       return this;
     }

--- a/src/main/java/org/sendbird/client/api/MetadataApi.java
+++ b/src/main/java/org/sendbird/client/api/MetadataApi.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class MetadataApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/ModerationApi.java
+++ b/src/main/java/org/sendbird/client/api/ModerationApi.java
@@ -44,7 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ModerationApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/OpenChannelApi.java
+++ b/src/main/java/org/sendbird/client/api/OpenChannelApi.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class OpenChannelApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/PinAMessageApi.java
+++ b/src/main/java/org/sendbird/client/api/PinAMessageApi.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class PinAMessageApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/PollApi.java
+++ b/src/main/java/org/sendbird/client/api/PollApi.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class PollApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/PrivacyApi.java
+++ b/src/main/java/org/sendbird/client/api/PrivacyApi.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class PrivacyApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/PushNotificationsApi.java
+++ b/src/main/java/org/sendbird/client/api/PushNotificationsApi.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class PushNotificationsApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/ReportApi.java
+++ b/src/main/java/org/sendbird/client/api/ReportApi.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ReportApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/ScheduledMessageApi.java
+++ b/src/main/java/org/sendbird/client/api/ScheduledMessageApi.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ScheduledMessageApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/StatisticsApi.java
+++ b/src/main/java/org/sendbird/client/api/StatisticsApi.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class StatisticsApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/UserApi.java
+++ b/src/main/java/org/sendbird/client/api/UserApi.java
@@ -49,7 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class UserApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/api/WebhookApi.java
+++ b/src/main/java/org/sendbird/client/api/WebhookApi.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class WebhookApi {
   private ApiClient apiClient;
 

--- a/src/main/java/org/sendbird/client/auth/ApiKeyAuth.java
+++ b/src/main/java/org/sendbird/client/auth/ApiKeyAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/org/sendbird/client/auth/HttpBasicAuth.java
+++ b/src/main/java/org/sendbird/client/auth/HttpBasicAuth.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class HttpBasicAuth implements Authentication {
   private String username;
   private String password;

--- a/src/main/java/org/sendbird/client/auth/HttpBearerAuth.java
+++ b/src/main/java/org/sendbird/client/auth/HttpBearerAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-30T22:30:42.640512+09:00[Asia/Seoul]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-07-15T20:36:02.608219+09:00[Asia/Seoul]")
 public class HttpBearerAuth implements Authentication {
   private final String scheme;
   private String bearerToken;


### PR DESCRIPTION
- Incorrectly required fields in `PUT /open_channels/{channel_url}`
  - Made all options except channel_url as optional
- Required fields in `PUT /users/{user_id}`
  - Made nickname and profile_url optional
- `GET /group_channels/{channel_url}/messages/unread_count`
    - Added support for multiple `user_ids` in the query parameters.
- Removed the redundant property `isFrozen` in `GroupChannel`, `Open Channel`
    - Use `freeze` instead.
- `DELETE /users/{user_id}/push/{token_type}/{token}`
    - Fixed the incorrect response type: `token` is now a string, not an array of strings.
- `GET /{channel_type}/{channel_url}/messages`
    - Fixed the issue with `og:image` missing the "type" field