### PR TITLE
[CPLAT-9677] chore: Add coding-agent instruction entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+This file is the source of truth for coding-agent instructions in this repository.
+
+## General Agent Guidance
+
+- Follow existing repository instructions first.
+- Preserve existing `AGENTS.md`, `CLAUDE.md`, README, CI, release, and owner guidance.
+- Do not overwrite repository-specific conventions with generic defaults.
+
+## Safety Rules
+
+- Do not make destructive or irreversible changes without explicit approval.
+- Do not bypass branch protection, required checks, required reviewers, scanners, or tests.
+- Do not force-push to protected branches or someone else's branch.
+- Do not commit secrets, tokens, credentials, customer data, or private keys.
+- Do not weaken authentication, authorization, IAM/RBAC, TLS, crypto, network exposure, or data-access controls without explicit approval.
+- Do not disable TLS verification except in clearly dev-only code with a written rationale.
+- Do not log secrets, auth headers, cookies, payment data, or customer PII.
+- Use synthetic test data; do not add real customer data to tests, fixtures, or seed files.
+
+## Review And Escalation
+
+Stop and ask before changing:
+
+- production data, infra, deploy, or config
+- secrets, auth, IAM, network exposure, or crypto
+- public APIs or compatibility-sensitive behavior
+- dependency/security scanner configuration
+- anything destructive or hard to roll back
+
+<!-- Add repository-specific coding-agent instructions below this line. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+Read [AGENTS.md](AGENTS.md) for coding-agent instructions in this repository.


### PR DESCRIPTION
## Summary

- Adds coding-agent instruction entrypoint files where one or both files are missing.
- **AGENTS.md**: Source of truth for coding-agent instructions, with baseline safety guidance.
- **CLAUDE.md**: Thin pointer to AGENTS.md.

Repositories that already have both files are out of scope and are not modified.

## Details

- Existing `AGENTS.md` files are preserved.
- Existing `CLAUDE.md` files are preserved.
- Repositories without `AGENTS.md` receive baseline safety guidance plus space for future repo-specific instructions.

## Test plan

- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Verify CLAUDE.md links to AGENTS.md correctly
- [ ] No existing files are overwritten